### PR TITLE
Move aiohttp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "aiohttp>=3.8.1"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
@@ -15,6 +15,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+]
+dependencies = [
+  "aiohttp = ">=3.8.1,<4",
 ]
 
 [project.urls]


### PR DESCRIPTION
`aiohttp` is a [runtime requirement](https://github.com/MarkGodwin/tplink-omada-api/blob/master/src/tplink_omada_client/omadaclient.py#L4).