### PR TITLE
Fix typo in LinkSpeed constant

### DIFF
--- a/src/tplink_omada_client/definitions.py
+++ b/src/tplink_omada_client/definitions.py
@@ -52,7 +52,7 @@ class LinkSpeed(IntEnum):
     """ Known link speeds. """
     SPEED_AUTO = 0
     SPEED_10_MBPS = 1
-    SPEED_100_MBDS = 2
+    SPEED_100_MBPS = 2
     SPEED_1_GBPS = 3
     SPEED_10_GBPS = 4
 


### PR DESCRIPTION
This might be a breaking change, but it's probably better to fix it before it is widely used than later on.