### PR TITLE
Cleanup session when login fails

### DIFF
--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -42,8 +42,13 @@ class OmadaApiConnection:
         return self._session
 
     async def __aenter__(self):
-        await self.login()
-        return self
+        try:
+            await self.login()
+            return self
+        except Exception as error:
+            if self._own_session:
+                await self.close()
+            raise error
 
     async def __aexit__(self, *args):
         """Call when the client is disposed."""


### PR DESCRIPTION
When `login()` failes I get errors like:
```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7f1378112100>
```
This fixes that problem