### PR TITLE
Fix missing key exception when device doesn't have 'uplink'

### DIFF
--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -238,6 +238,8 @@ class OmadaSwitch(OmadaDevice):
     @property
     def uplink(self) -> Optional[OmadaUplink]:
         """ Uplink device for this switch. """
+        if not "uplink" in self._data:
+            return None
         uplink = self._data["uplink"]
         if uplink is None:
             return None


### PR DESCRIPTION
My 'root' switch doesn't have an uplink and when trying to check `if device.uplink is None`, I get a missing key exception. This fixes that problem. I'm guessing the second `if uplink is None` check in the `uplink` property is redundant but better safe than sorry so I left it there.