### PR TITLE
Feature/raw data

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,36 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Test Client",
+            "name": "CLI: List Devices",
             "type": "python",
             "request": "launch",
-            "program": "sample_client.py",
-            "console": "integratedTerminal",
+            "module": "tplink_omada_client.cli",
             "justMyCode": true,
-            "args": ["https://192.168.1.50", "admin", "admin"]
+            "args": ["devices"]
+        },
+        {
+            "name": "CLI: List Targets",
+            "type": "python",
+            "request": "launch",
+            "module": "tplink_omada_client.cli",
+            "justMyCode": true,
+            "args": ["targets"]
+        },
+        {
+            "name": "CLI: List Switches",
+            "type": "python",
+            "request": "launch",
+            "module": "tplink_omada_client.cli",
+            "justMyCode": true,
+            "args": ["switches"]
+        },
+        {
+            "name": "CLI: Get Switch",
+            "type": "python",
+            "request": "launch",
+            "module": "tplink_omada_client.cli",
+            "justMyCode": true,
+            "args": ["switch", "Main Switch", "--dump"]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This package provides a simple CLI for interacting with one or more Omada Contro
 CLI, you must first target a Controller.
 
 ```sh
-$ omada -t NAME target --url https://your.omada.controller.here --user admin --password password --site MySite
+$ omada -t NAME target --url https://your.omada.controller.here --user admin --password password --site MySite --set-default
 ```
 
 Where `NAME` is a name of your choosing to identify the targeted controller. `--site` defaults to the Omada
@@ -39,7 +39,7 @@ password.
 Once you have successfully targeted a controller you can test that things are working by running:
 
 ```sh
-$ omada -t NAME devices
+$ omada devices
 ```
 
 This will list all the devices being managed by your controller.
@@ -49,6 +49,9 @@ To see a list of all the available commands, run:
 ```sh
 $ omada -h
 ```
+
+You can set up multiple targets (controllers and sites), and specify the target with the `-t <NAME>` parameter.
+If you don't specify a target, the default will be used, if that has been set.
 
 The CLI is still young so if there is any functionality you need, please create an issue and let us know.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.2.1"
+version = "1.2.2"
 authors = [
   { name="Mark Godwin", email="author@example.com" },
 ]

--- a/src/tplink_omada_client/cli/__init__.py
+++ b/src/tplink_omada_client/cli/__init__.py
@@ -12,6 +12,7 @@ from . import (
     command_switches,
     command_target,
     command_targets,
+    command_default
 )
 
 def main(argv: Union[Sequence[str], None] = None) -> int:
@@ -22,6 +23,7 @@ def main(argv: Union[Sequence[str], None] = None) -> int:
     parser.add_argument(
         '-t', '--target',
         help="The target Omada controller",
+        default=""
     )
 
     subparsers = parser.add_subparsers(
@@ -34,6 +36,7 @@ def main(argv: Union[Sequence[str], None] = None) -> int:
     command_switches.arg_parser(subparsers)
     command_target.arg_parser(subparsers)
     command_targets.arg_parser(subparsers)
+    command_default.arg_parser(subparsers)
 
     try:
         args = parser.parse_args(args=argv)

--- a/src/tplink_omada_client/cli/command_default.py
+++ b/src/tplink_omada_client/cli/command_default.py
@@ -1,0 +1,22 @@
+"""Implementation of 'default' command"""
+from argparse import _SubParsersAction, ArgumentError
+import getpass
+
+from .util import assert_target_argument
+from .config import ControllerConfig, set_default_target, to_omada_connection, get_target_config
+
+async def command_target(args) -> int:
+    """Executes 'default' command"""
+    target = assert_target_argument(args)
+    config = get_target_config(target)
+
+    set_default_target(target)
+    return 0
+
+def arg_parser(subparsers: _SubParsersAction) -> None:
+    """Configures argument parser for 'default' command"""
+    set_parser = subparsers.add_parser(
+        "default",
+        help="Sets the default target",
+    )
+    set_parser.set_defaults(func=command_target)

--- a/src/tplink_omada_client/cli/command_devices.py
+++ b/src/tplink_omada_client/cli/command_devices.py
@@ -1,19 +1,20 @@
 """Implementation for 'devices' command"""
 
 from argparse import _SubParsersAction
-
+import json
 from .config import get_target_config, to_omada_connection
-from .util import assert_target_argument
+from .util import dump_raw_data, get_target_argument
 
 async def command_devices(args) -> int:
     """Executes 'devices' command"""
-    controller = assert_target_argument(args)
+    controller = get_target_argument(args)
     config = get_target_config(controller)
 
     async with to_omada_connection(config) as client:
         site_client = await client.get_site_client(config.site)
         for device in await site_client.get_devices():
-            print(f"{device.mac} {device.ip_address:>15} {device.type:>6}  {device.name:20} {device.model_display_name}")
+            print(f"{device.mac} {device.ip_address:>15} {device.type:>7}  {device.name:20} {device.model_display_name}")
+            dump_raw_data(args, device)
     return 0
 
 def arg_parser(subparsers: _SubParsersAction) -> None:
@@ -22,4 +23,6 @@ def arg_parser(subparsers: _SubParsersAction) -> None:
         "devices",
         aliases=['d'],
         help="Lists devices managed by Omada Controller")
+    devices_parser.add_argument('-d', '--dump', help="Output raw device information",  action='store_true')
+
     devices_parser.set_defaults(func=command_devices)

--- a/src/tplink_omada_client/cli/command_switches.py
+++ b/src/tplink_omada_client/cli/command_switches.py
@@ -3,11 +3,11 @@
 from argparse import _SubParsersAction
 
 from .config import get_target_config, to_omada_connection
-from .util import assert_target_argument
+from .util import dump_raw_data, get_target_argument
 
 async def command_switches(args) -> int:
     """Executes 'switches' command"""
-    controller = assert_target_argument(args)
+    controller = get_target_argument(args)
     config = get_target_config(controller)
 
     async with to_omada_connection(config) as client:
@@ -25,6 +25,8 @@ async def command_switches(args) -> int:
                     print("\u26a1", end="")
                 else:
                     print("  ", end="")
+
+            dump_raw_data(args, switch)
             print()
     return 0
 
@@ -35,3 +37,4 @@ def arg_parser(subparsers: _SubParsersAction) -> None:
         aliases=['s'],
         help="Lists switches managed by Omada Controller")
     switches_parser.set_defaults(func=command_switches)
+    switches_parser.add_argument('-d', '--dump', help="Output raw device information",  action='store_true')

--- a/src/tplink_omada_client/cli/command_targets.py
+++ b/src/tplink_omada_client/cli/command_targets.py
@@ -8,8 +8,8 @@ from .config import (
 async def command_targets(args) -> int: # pylint: disable=unused-argument
     """Executes 'targets' command"""
     controllers = get_targets()
-    for (controller, url) in controllers:
-        print(f"{controller:15} {url}")
+    for (controller, url, is_default) in controllers:
+        print(f"{('*' if is_default else' ')} {controller:15} {url}")
     return 0
 
 def arg_parser(subparsers: _SubParsersAction) -> None:

--- a/src/tplink_omada_client/cli/config.py
+++ b/src/tplink_omada_client/cli/config.py
@@ -1,4 +1,4 @@
-"""Responsible for ~/.omada.ini"""
+"""Responsible for ~/.omada.cfg"""
 from configparser import ConfigParser
 from dataclasses import dataclass
 from pathlib import Path
@@ -7,6 +7,8 @@ from tplink_omada_client.omadaclient import OmadaClient
 
 _CONFIG_FILE: Path = Path.home() / '.omada.cfg'
 _CONTROLLER_SECTION_PREFIX: str = 'controller:'
+_CLI_SECTION: str = "cli"
+_DEFAULT_TARGET: str = "default_target"
 
 @dataclass
 class ControllerConfig:
@@ -16,26 +18,34 @@ class ControllerConfig:
     password: str
     site: str
 
-def get_targets() -> list[tuple[str, str]]:
+def get_targets() -> list[tuple[str, str, bool]]:
     """Get all the controllers in config file"""
     config_parser = _read_config_file()
+    default_target = config_parser[_CLI_SECTION][_DEFAULT_TARGET] if _CLI_SECTION in config_parser else ""
     targets = []
     for (target, config) in config_parser.items():
         if target.startswith(_CONTROLLER_SECTION_PREFIX):
             name = target[len(_CONTROLLER_SECTION_PREFIX):]
-            targets.append((name, config["url"]))
+            targets.append((name, config["url"], name == default_target))
     return targets
 
 def get_target_config(name: str) -> ControllerConfig:
     """Using controller name to create Omada site client"""
     config = _read_config_file()
+
+    if name == "":
+        if _CLI_SECTION in config:
+            name = config[_CLI_SECTION][_DEFAULT_TARGET]
+        if not name:
+            raise ValueError(f"No target specified, and no default target has been configured.")
+        
     stored_name = _to_stored_name(name)
     if config.has_section(stored_name):
         stored_config = config[stored_name]
         return ControllerConfig(**stored_config)
     raise ValueError(f"Could not find target named '{name}'")
 
-def set_target_config(name: str, config: ControllerConfig) -> None:
+def set_target_config(name: str, config: ControllerConfig, set_default: bool) -> None:
     """Stores controller config in users's config file"""
     stored_name = _to_stored_name(name)
     config_parser = _read_config_file()
@@ -45,8 +55,19 @@ def set_target_config(name: str, config: ControllerConfig) -> None:
     config_parser.set(stored_name, "username", config.username)
     config_parser.set(stored_name, "password", config.password)
     config_parser.set(stored_name, "site", config.site)
-    with _CONFIG_FILE.open(mode='w') as file:
-        config_parser.write(file)
+    if set_default:
+        if not config_parser[_CLI_SECTION]:
+            config_parser[_CLI_SECTION] = {}
+        config_parser[_CLI_SECTION][_DEFAULT_TARGET] = name
+
+    _write_config_file(config_parser)
+
+def set_default_target(name: str) -> None:
+    config_parser = _read_config_file()
+    if _CLI_SECTION not in config_parser:
+        config_parser[_CLI_SECTION] = {}
+    config_parser[_CLI_SECTION][_DEFAULT_TARGET] = name
+    _write_config_file(config_parser)
 
 def to_omada_connection(config: ControllerConfig) -> OmadaClient:
     """Create a OmadaClient based on a ControllerConfig object"""
@@ -59,6 +80,12 @@ def _read_config_file() -> ConfigParser:
         with _CONFIG_FILE.open() as file:
             config.read_file(file)
     return config
+
+def _write_config_file(config_parser):
+    """Write the user's config file"""
+    with _CONFIG_FILE.open(mode='w') as file:
+        config_parser.write(file)
+
 
 def _to_stored_name(name: str) -> str:
     return _CONTROLLER_SECTION_PREFIX + name

--- a/src/tplink_omada_client/cli/util.py
+++ b/src/tplink_omada_client/cli/util.py
@@ -1,12 +1,36 @@
 """Common functionality for multiple commands"""
 import argparse
+import json
 
 from typing import Any
+from re import IGNORECASE, match
+from tplink_omada_client.devices import OmadaApiData
+from tplink_omada_client.omadasiteclient import OmadaSiteClient
 
 TARGET_ARG: str = "target"
 
 def assert_target_argument(args: dict[str, Any]) -> str:
     """Throws ArgumentError if target arg missing"""
-    if TARGET_ARG not in args or args[TARGET_ARG] is None:
+    if args[TARGET_ARG] == "": # The default is now empty
         raise argparse.ArgumentError(None, f"error: Missing --{TARGET_ARG} argument")
     return args[TARGET_ARG]
+
+def get_target_argument(args: dict[str, Any]) -> str:
+    return args[TARGET_ARG]
+
+async def get_mac(site_client: OmadaSiteClient, mac_or_name: str) -> str:
+    if match('([0-9A-F]{2}[-]){5}[0-9A-F]{2}$',
+        string=mac_or_name,
+        flags=IGNORECASE):
+        return mac_or_name
+
+    device = next((d for d in await site_client.get_devices() if d.name == mac_or_name), None)
+    if not device:
+        raise argparse.ArgumentError(None, f"Device with name {mac_or_name} not found")
+    return device.mac
+
+def dump_raw_data(args: dict[str, Any], data: OmadaApiData):
+    if args['dump']:
+        print("--- BEGIN RAW DATA ---")
+        print(json.dumps(data.raw_data, indent=2))
+        print("---  END RAW DATA  ---")

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -3,7 +3,7 @@ Definitions for Omada device objects
 
 APs, Switches and Routers
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 from .definitions import (
     BandwidthControl,
     DeviceStatus,
@@ -15,12 +15,17 @@ from .definitions import (
     PortType,
 )
 
-
-class OmadaDevice:
-    """Details of a device connected to the controller"""
-
-    def __init__(self, data: Dict[str, Any]):
+class OmadaApiData:
+    def __init__(self, data: dict[str, Any]):
         self._data = data
+
+    @property
+    def raw_data(self) -> dict[str, Any]:
+        return self._data
+
+
+class OmadaDevice(OmadaApiData):
+    """Details of a device connected to the controller"""
 
     @property
     def type(self) -> str:
@@ -92,11 +97,8 @@ class OmadaListDevice(OmadaDevice):
         return self._data["fwDownload"]
 
 
-class OmadaLink:
+class OmadaLink(OmadaApiData):
     """Up/Downlink connection from a switch/ap device."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self._data = data
 
     @property
     def mac(self) -> str:
@@ -137,11 +139,8 @@ class OmadaUplink(OmadaLink):
     """Uplink connection from a switch/ap device."""
 
 
-class OmadaPortStatus:
+class OmadaPortStatus(OmadaApiData):
     """Status information for a switch port."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self._data = data
 
     @property
     def link_status(self) -> LinkStatus:
@@ -181,11 +180,8 @@ class OmadaPortStatus:
         return self._data["stpDiscarding"]
 
 
-class OmadaSwitchPort:
+class OmadaSwitchPort(OmadaApiData):
     """Port on a switch/gateway device."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self._data = data
 
     @property
     def port(self) -> int:
@@ -223,11 +219,8 @@ class OmadaSwitchPort:
         return OmadaPortStatus(self._data["portStatus"])
 
 
-class OmadaSwitchDeviceCaps:
+class OmadaSwitchDeviceCaps(OmadaApiData):
     """Capabilities of a switch."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self._data = data
 
     @property
     def poe_ports(self) -> int:
@@ -284,11 +277,8 @@ class OmadaSwitch(OmadaDevice):
         return OmadaSwitchDeviceCaps(self._data["devCap"])
 
 
-class OmadaAccesPointLanPortSettings:
+class OmadaAccesPointLanPortSettings(OmadaApiData):
     """A LAN port on an access point."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self._data = data
 
     @property
     def port_name(self) -> str:
@@ -449,11 +439,8 @@ class OmadaSwitchPortDetails(OmadaSwitchPort):
         return self._data["portIsolationEnable"]
 
 
-class OmadaPortProfile:
+class OmadaPortProfile(OmadaApiData):
     """Definition of a switch port configuration profile."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self._data = data
 
     @property
     def profile_id(self) -> str:
@@ -511,11 +498,8 @@ class OmadaPortProfile:
         return self._data["portIsolationEnable"]
 
 
-class OmadaInterfaceDetails:
+class OmadaInterfaceDetails(OmadaApiData):
     """Basic UI Information about controller."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self._data = data
 
     @property
     def controller_name(self) -> str:
@@ -523,11 +507,8 @@ class OmadaInterfaceDetails:
         return self._data["controllerName"]
 
 
-class OmadaFirmwareUpdate:
+class OmadaFirmwareUpdate(OmadaApiData):
     """Status information for a switch port."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self._data = data
 
     @property
     def current_version(self) -> str:


### PR DESCRIPTION
Added options to the CLI to allow dumping of raw JSON data, to help diagnose problems in the wild.
Added default target support, so -t parameter becomes optional.
Allow querying switches by name as well as mac, jff.