### PR TITLE
Improve meaning of PoE power value when switch port has no PoE capability

### DIFF
--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -3,7 +3,6 @@ Definitions for Omada device objects
 
 APs, Switches and Routers
 """
-import math
 from typing import Any, List, Optional, Union
 from .definitions import (
     BandwidthControl,
@@ -18,6 +17,7 @@ from .definitions import (
     PoEMode,
     PortType,
 )
+
 
 class OmadaApiData:
     def __init__(self, data: dict[str, Any]):
@@ -192,7 +192,7 @@ class OmadaPortStatus(OmadaApiData):
         """Power (W) supplied over PoE."""
         if "poePower" in self._data:
             return self._data["poePower"]
-        return math.nan
+        return None
 
     @property
     def bytes_tx(self) -> int:

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -188,11 +188,9 @@ class OmadaPortStatus(OmadaApiData):
         return self._data["poe"]
 
     @property
-    def poe_power(self) -> float:
+    def poe_power(self) -> Optional[float]:
         """Power (W) supplied over PoE."""
-        if "poePower" in self._data:
-            return self._data["poePower"]
-        return None
+        return self._data.get("poePower")
 
     @property
     def bytes_tx(self) -> int:

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -3,6 +3,7 @@ Definitions for Omada device objects
 
 APs, Switches and Routers
 """
+import math
 from typing import Any, List, Optional, Union
 from .definitions import (
     BandwidthControl,
@@ -191,7 +192,7 @@ class OmadaPortStatus(OmadaApiData):
         """Power (W) supplied over PoE."""
         if "poePower" in self._data:
             return self._data["poePower"]
-        return 0.0
+        return math.nan
 
     @property
     def bytes_tx(self) -> int:


### PR DESCRIPTION
A port without any device connected will be reported as a `LINK_DOWN` link status on that port.
The API consumer can rely on that piece of information to detect an unused port.

But when the link status is `LINK_UP`:
- a port reporting a 0.0 power consumption means that the port **HAS PoE capability**, BUT no power is consumed by any device,
- a port reporting no PoE power value in the json payload returned by the Omada API means that the port **has NO PoE capability**.

The lack of PoE capability on one port can only be determined by a missing `poe_power` value in the Omada API output.
Thus, returning a `None` would be a lot more meaningful (without making the `tplink_omada_client` API too difficult to consume).