### PR TITLE
Add the ability to request a neutral SwitchPortOverrides for a particular port

### DIFF
--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -84,7 +84,7 @@ class OmadaDevice(OmadaApiData):
             return self._data["cpuUtil"]
         else:
             return 0
-        
+
     @property
     def mem_usage(self) -> int:
         if self._data["statusCategory"] == DeviceStatusCategory.CONNECTED:
@@ -399,6 +399,16 @@ class OmadaSwitchPortDetails(OmadaSwitchPort):
         return LinkSpeed(self._data["maxSpeed"])
 
     @property
+    def link_speed(self) -> LinkSpeed:
+        """The link speed of the port."""
+        return LinkSpeed(self._data["linkSpeed"])
+
+    @property
+    def duplex(self) -> LinkDuplex:
+        """The link duplex state of the port."""
+        return LinkDuplex(self._data['duplex'])
+
+    @property
     def profile_name(self) -> str:
         """Name of the port's config profile"""
         return self._data["profileName"]
@@ -556,7 +566,7 @@ class OmadaFirmwareUpdate(OmadaApiData):
 
 class OmadaGatewayPort(OmadaApiData):
 
-    
+
     @property
     def port_number(self) -> int:
         return self._data["port"]
@@ -657,7 +667,7 @@ class OmadaGateway(OmadaDevice):
     def ip(self) -> str:
         """Gateway's LAN IP address."""
         return self._data["ip"]
-        
+
     @property
     def port_status(self) -> List[OmadaGatewayPort]:
         """Status of the gateway's ports."""
@@ -665,7 +675,7 @@ class OmadaGateway(OmadaDevice):
             OmadaGatewayPort(p) for p in self._data["portStats"]
         ]
 
-    @property 
+    @property
     def port_configs(self) -> List[OmadaGatewayPortConfig]:
         """Configuration of the gateway's ports. Also includes status..."""
         return [


### PR DESCRIPTION
This allows to change the PoE mode of a single port, using ports overrides, without changing any other setting of the port, no matter how they are currently set.

The PoE switching method in the Home Assistant TP-Link Omada integration could then be changed from:
```python
    async def _async_turn_on_off_poe(self, enable: bool) -> None:
        self.port_details = await self.omada_client.update_switch_port(
            self.device,
            self.port_details,
            overrides=SwitchPortOverrides(enable_poe=enable),
        )
        self._refresh_state()
```
To:
```python
    async def _async_turn_on_off_poe(self, enable: bool) -> None:
        overrides = await self.omada_client.get_switch_port_overrides(device, port_details)
        overrides.enable_poe = enable
        self.port_details = await self.omada_client.update_switch_port(
            self.device,
            self.port_details,
            overrides,
        )
        self._refresh_state()
```
Hence without changing any of the port other settings.

The counterpart is that it uses one more API call to get the port status, and one more again if the port has no active overrides yet (in order to populate the neutral override settings with the port associated _profile_ settings, which should mostly happen only once).