### PR TITLE
Add client API support

### DIFF
--- a/src/tplink_omada_client/cli/__init__.py
+++ b/src/tplink_omada_client/cli/__init__.py
@@ -7,14 +7,19 @@ from typing import Any, Sequence, Union
 from tplink_omada_client.exceptions import LoginFailed
 
 from . import (
+    command_block_client,
+    command_client,
+    command_clients,
+    command_default,
     command_devices,
+    command_known_clients,
+    command_gateway,
     command_switch,
     command_switches,
     command_target,
     command_targets,
-    command_default,
-    command_gateway,
-    command_switch_ports
+    command_switch_ports,
+    command_unblock_client,
 )
 
 def main(argv: Union[Sequence[str], None] = None) -> int:
@@ -33,14 +38,19 @@ def main(argv: Union[Sequence[str], None] = None) -> int:
         metavar='command',
     )
 
+    command_block_client.arg_parser(subparsers)
+    command_client.arg_parser(subparsers)
+    command_clients.arg_parser(subparsers)
+    command_default.arg_parser(subparsers)
     command_devices.arg_parser(subparsers)
+    command_gateway.arg_parser(subparsers)
+    command_known_clients.arg_parser(subparsers)
     command_switch.arg_parser(subparsers)
     command_switches.arg_parser(subparsers)
     command_switch_ports.arg_parser(subparsers)
     command_target.arg_parser(subparsers)
     command_targets.arg_parser(subparsers)
-    command_default.arg_parser(subparsers)
-    command_gateway.arg_parser(subparsers)
+    command_unblock_client.arg_parser(subparsers)
 
     try:
         args = parser.parse_args(args=argv)

--- a/src/tplink_omada_client/cli/command_block_client.py
+++ b/src/tplink_omada_client/cli/command_block_client.py
@@ -1,0 +1,31 @@
+"""Implementation for 'client' command"""
+
+from argparse import _SubParsersAction
+import datetime
+from tplink_omada_client.clients import OmadaWiredClientDetails, OmadaWirelessClientDetails
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_client_mac, get_target_argument
+
+async def command_block_client(args) -> int:
+    """Executes 'block-client' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        mac = await get_client_mac(site_client, args['mac'])
+        await site_client.block_client(mac)
+    return 0
+
+def arg_parser(subparsers: _SubParsersAction) -> None:
+    """Configures arguments parser for 'block-client' command"""
+    block_parser = subparsers.add_parser(
+        "block-client",
+        help="Blocks a client from the accessing the network")
+
+    block_parser.add_argument(
+        "mac",
+        help="The MAC address or name of the client",
+    )
+
+    block_parser.set_defaults(func=command_block_client)

--- a/src/tplink_omada_client/cli/command_client.py
+++ b/src/tplink_omada_client/cli/command_client.py
@@ -1,0 +1,53 @@
+"""Implementation for 'client' command"""
+
+from argparse import _SubParsersAction
+import datetime
+from tplink_omada_client.clients import OmadaWiredClientDetails, OmadaWirelessClientDetails
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_client_mac, get_target_argument
+
+async def command_client(args) -> int:
+    """Executes 'client' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        mac = await get_client_mac(site_client, args['mac'])
+        client = await site_client.get_client(mac)
+        print(f"Name: {client.name}")
+        print(f"MAC: {client.mac}")
+        if client.ip:
+            print(f"IP: {client.ip}")
+        if client.host_name:
+            print(f"Hostname: {client.host_name}")
+        print(f"Blocked: {client.is_blocked}")
+        if client.is_active:
+            uptime = str(datetime.timedelta(seconds=client.connection_time))
+            print(f"Uptime: {uptime}")
+        if isinstance(client, OmadaWiredClientDetails):
+            if client.connect_dev_type == 'switch':
+                print(f"Switch: {client.switch_name} ({client.switch_mac})")
+                print(f"Switch port: {client.port}")
+            elif client.connect_dev_type == 'gateway':
+                print(f"Gateway: {client.gateway_name} ({client.gateway_mac})")
+        elif isinstance(client, OmadaWirelessClientDetails):
+            print(f"SSID: {client.ssid}")
+            print(f"Access Point: {client.ap_name} ({client.ap_mac})")
+        
+        dump_raw_data(args, client)
+    return 0
+
+def arg_parser(subparsers: _SubParsersAction) -> None:
+    """Configures arguments parser for 'client' command"""
+    client_parser = subparsers.add_parser(
+        "client",
+        help="Shows details of a client known to Omada controller")
+
+    client_parser.add_argument(
+        "mac",
+        help="The MAC address or name of the client",
+    )
+    client_parser.add_argument('-d', '--dump', help="Output raw client information",  action='store_true')
+
+    client_parser.set_defaults(func=command_client)

--- a/src/tplink_omada_client/cli/command_clients.py
+++ b/src/tplink_omada_client/cli/command_clients.py
@@ -1,0 +1,41 @@
+"""Implementation for 'clients' command"""
+
+from argparse import _SubParsersAction
+from tplink_omada_client.clients import OmadaConnectedClient, OmadaWiredClient, OmadaWirelessClient
+from tplink_omada_client.definitions import ConnectType
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_target_argument
+
+async def command_clients(args) -> int:
+    """Executes 'clients' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        async for client in site_client.get_connected_clients():
+            if client.ip:
+                ip = client.ip
+            else:
+                ip = '-'
+            print(f"{client.mac} {ip:15} {(client.name if not None else ''):20} ", end = "")
+            if isinstance(client, OmadaWiredClient):
+                if client.connect_dev_type == 'switch':
+                    print(f"{client.switch_name} ({client.port})")
+                elif client.connect_dev_type == 'gateway':
+                    print(f"{client.gateway_name}")
+
+            elif isinstance(client, OmadaWirelessClient):
+                print(f"{client.ssid} ({client.ap_name})")
+            dump_raw_data(args, client)
+    return 0
+
+def arg_parser(subparsers: _SubParsersAction) -> None:
+    """Configures arguments parser for 'clients' command"""
+    clients_parser = subparsers.add_parser(
+        "clients",
+        aliases=['c'],
+        help="Lists clients connected to site network")
+    clients_parser.add_argument('-d', '--dump', help="Output raw client information",  action='store_true')
+
+    clients_parser.set_defaults(func=command_clients)

--- a/src/tplink_omada_client/cli/command_gateway.py
+++ b/src/tplink_omada_client/cli/command_gateway.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 from tplink_omada_client.definitions import GatewayPortMode, LinkStatus
 
 from .config import get_target_config, to_omada_connection
-from .util import dump_raw_data, get_link_status_char, get_mac, get_target_argument
+from .util import dump_raw_data, get_link_status_char, get_device_mac, get_target_argument
 
 async def command_gateway(args) -> int:
     """Executes 'gateway' command"""
@@ -16,7 +16,7 @@ async def command_gateway(args) -> int:
         site_client = await client.get_site_client(config.site)
         mac = args['mac']
         if mac:
-            mac = await get_mac(site_client, mac)
+            mac = await get_device_mac(site_client, mac)
         gateway = await site_client.get_gateway(mac)
         print(f"Name: {gateway.name}")
         print(f"Address: {gateway.mac} ({gateway.ip_address})")

--- a/src/tplink_omada_client/cli/command_known_clients.py
+++ b/src/tplink_omada_client/cli/command_known_clients.py
@@ -1,0 +1,39 @@
+"""Implementation for 'known-clients' command"""
+
+from argparse import _SubParsersAction
+from datetime import datetime
+from tplink_omada_client.clients import OmadaConnectedClient, OmadaWiredClient, OmadaWirelessClient
+from tplink_omada_client.definitions import ConnectType
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_target_argument
+
+async def command_known_clients(args) -> int:
+    """Executes 'known-clients' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        async for client in site_client.get_known_clients():
+            if client.mac == client.name:
+                name = ""
+            else:
+                name = f" {client.name}"
+            if client.is_blocked:
+                blocked = "blocked"
+            else:
+                blocked = ""
+            lastseen = str(datetime.utcfromtimestamp(client.last_seen))
+            print(f"{client.mac}{name:<25}{blocked:<8} {lastseen}")
+            dump_raw_data(args, client)
+
+    return 0
+
+def arg_parser(subparsers: _SubParsersAction) -> None:
+    """Configures arguments parser for 'known-clients' command"""
+    known_clients_parser = subparsers.add_parser(
+        "known-clients",
+        help="Lists all clients known to the Omada controller")
+    known_clients_parser.add_argument('-d', '--dump', help="Output raw client information",  action='store_true')
+
+    known_clients_parser.set_defaults(func=command_known_clients)

--- a/src/tplink_omada_client/cli/command_switch.py
+++ b/src/tplink_omada_client/cli/command_switch.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 
 from .config import get_target_config, to_omada_connection
-from .util import dump_raw_data, get_mac, get_target_argument
+from .util import dump_raw_data, get_device_mac, get_target_argument
 
 async def command_switch(args) -> int:
     """Executes 'switch' command"""
@@ -12,7 +12,7 @@ async def command_switch(args) -> int:
 
     async with to_omada_connection(config) as client:
         site_client = await client.get_site_client(config.site)
-        mac = await get_mac(site_client, args['mac'])
+        mac = await get_device_mac(site_client, args['mac'])
         switch = await site_client.get_switch(mac)
         print(f"Name: {switch.name}")
         print(f"Address: {switch.mac} ({switch.ip_address})")

--- a/src/tplink_omada_client/cli/command_switch_ports.py
+++ b/src/tplink_omada_client/cli/command_switch_ports.py
@@ -7,7 +7,7 @@ from tplink_omada_client.definitions import LinkStatus, PoEMode, PortType
 from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
 
 from .config import get_target_config, to_omada_connection
-from .util import dump_raw_data, get_checkbox_char, get_link_status_char, get_mac, get_power_char, get_target_argument
+from .util import dump_raw_data, get_checkbox_char, get_link_status_char, get_device_mac, get_power_char, get_target_argument
 
 async def command_switch_ports(args) -> int:
     """Executes 'switch_ports' command"""
@@ -16,7 +16,7 @@ async def command_switch_ports(args) -> int:
 
     async with to_omada_connection(config) as client:
         site_client = await client.get_site_client(config.site)
-        mac = await get_mac(site_client, args['mac'])
+        mac = await get_device_mac(site_client, args['mac'])
         switch = await site_client.get_switch(mac)
         ports = await site_client.get_switch_ports(mac)
 

--- a/src/tplink_omada_client/cli/command_unblock_client.py
+++ b/src/tplink_omada_client/cli/command_unblock_client.py
@@ -1,0 +1,31 @@
+"""Implementation for 'client' command"""
+
+from argparse import _SubParsersAction
+import datetime
+from tplink_omada_client.clients import OmadaWiredClientDetails, OmadaWirelessClientDetails
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_client_mac, get_target_argument
+
+async def command_unblock_client(args) -> int:
+    """Executes 'unblock-client' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        mac = await get_client_mac(site_client, args['mac'])
+        await site_client.unblock_client(mac)
+    return 0
+
+def arg_parser(subparsers: _SubParsersAction) -> None:
+    """Configures arguments parser for 'unblock-client' command"""
+    unblock_parser = subparsers.add_parser(
+        "unblock-client",
+        help="Unblocks a client allowing access to the network")
+
+    unblock_parser.add_argument(
+        "mac",
+        help="The MAC address or name of the client",
+    )
+
+    unblock_parser.set_defaults(func=command_unblock_client)

--- a/src/tplink_omada_client/cli/util.py
+++ b/src/tplink_omada_client/cli/util.py
@@ -19,7 +19,18 @@ def assert_target_argument(args: dict[str, Any]) -> str:
 def get_target_argument(args: dict[str, Any]) -> str:
     return args[TARGET_ARG]
 
-async def get_mac(site_client: OmadaSiteClient, mac_or_name: str) -> str:
+async def get_client_mac(site_client: OmadaSiteClient, mac_or_name: str) -> str:
+    if match('([0-9A-F]{2}[-]){5}[0-9A-F]{2}$',
+        string=mac_or_name,
+        flags=IGNORECASE):
+        return mac_or_name
+
+    async for client in site_client.get_known_clients():
+        if client.name == mac_or_name:
+            return client.mac
+    raise argparse.ArgumentError(None, f"Client with name {mac_or_name} not found")
+
+async def get_device_mac(site_client: OmadaSiteClient, mac_or_name: str) -> str:
     if match('([0-9A-F]{2}[-]){5}[0-9A-F]{2}$',
         string=mac_or_name,
         flags=IGNORECASE):

--- a/src/tplink_omada_client/clients.py
+++ b/src/tplink_omada_client/clients.py
@@ -1,0 +1,290 @@
+from typing import cast, Optional
+
+from .definitions import (
+    AuthenticationStatus,
+    ConnectType,
+    OmadaApiData,
+    RadioId,
+    WifiMode,
+)
+
+class OmadaNetworkClient(OmadaApiData):
+    """Base representation of Omada client"""
+
+    @property
+    def connection_time(self) -> Optional[int]:
+        """ Client connection time in seconds. """
+        if "uptime" in self._data:
+            return self._data["uptime"]
+        if "duration" in self._data:
+            return self._data["duration"]
+        return None
+
+    @property
+    def is_blocked(self) -> bool:
+        # Most API calls return 'blocked' but the 'known_clients' call returns 'block'
+        return self._data.get("blocked", self._data.get("block", False))
+
+    @property
+    def is_guest(self) -> bool:
+        """ Indicates if client is a 'guest'. """
+        return self._data["guest"]
+
+    @property
+    def last_seen(self) -> float:
+        """ Timestamp in second from Unix Epoch when client was last connected. """
+        return self._data["lastSeen"] / 1000
+
+    @property
+    def mac(self) -> str:
+        """ The MAC address of the client. """
+        return self._data["mac"]
+
+    @property
+    def name(self) -> str:
+        """ The name of the client. """
+        return self._data["name"]
+
+    @property
+    def is_wireless(self) -> Optional[bool]:
+        """ Indicates if client is a wireless client """
+        return self._data.get("wireless")
+
+class OmadaConnectedClient(OmadaNetworkClient):
+    @property
+    def is_active(self) -> bool:
+        """ Indicates if client is active """
+        return self._data["active"]
+
+    @property
+    def activity(self) -> int:
+        """ Realtime downlink rate (Byte/s) """
+        return self._data["activity"]
+
+    @property
+    def auth_status(self) -> AuthenticationStatus:
+        """ Authentication status """
+        return self._data["authStatus"]
+
+    @property
+    def connect_dev_type(self) -> Optional[str]:
+        """ Connected device type (ap, gateway, switch) """
+        return self._data.get("connectDevType")
+
+    @property
+    def connect_type(self) -> ConnectType:
+        """ Connection type """
+        return self._data["connectType"]
+    
+    @property
+    def device_type(self) -> str:
+        """ Device type (Android, iPhone, iPod... mostly Unkown) """
+        return self._data["deviceType"]
+
+    @property
+    def down_packet(self) -> int:
+        """ Number of packets sent to client """
+        return self._data["downPacket"]
+
+    @property
+    def host_name(self) -> Optional[str]:
+        """ The client's hostname. """
+        return self._data.get("hostName")
+
+    @property
+    def ip(self) -> Optional[str]:
+        """ The client's IP address. """
+        return self._data.get("ip")
+
+    @property
+    def traffic_down(self) -> int:
+        """ Number of bytes sent to client """
+        return self._data["trafficDown"]
+
+    @property
+    def traffic_up(self) -> int:
+        """ Number of bytes sent by client """
+        return self._data["trafficUp"]
+
+    @property
+    def up_packet(self) -> int:
+        """ Number of packets received from client """
+        return self._data["upPacket"]
+
+    @property
+    def vlan(self) -> Optional[int]:
+        """
+        VLAN ID
+        
+        This property appears to work with some access points but is not provided
+        by others.
+
+        Known to work on: EAP653
+        Not provided by: EAP660
+        """
+        return self._data.get("vid")
+
+
+class IpSetting(OmadaApiData):
+
+    @property
+    def used_fixed_addr(self) -> bool:
+        return self._data["useFixedAddr"]
+    
+class RateLimit(OmadaApiData):
+    
+    @property
+    def enabled(self) -> bool:
+        return self._data["enable"]
+
+    @property
+    def down_enabled(self) -> bool:
+        return self._data["downEnable"]
+
+    @property
+    def down_limit(self) -> int:
+        return self._data["downLimit"]
+
+    @property
+    def down_unit(self) -> int:
+        return self._data["downUnit"]
+
+    @property
+    def up_enabled(self) -> bool:
+        return self._data["upEnable"]
+
+    @property
+    def up_limit(self) -> int:
+        return self._data["upLimit"]
+
+
+    @property
+    def up_unit(self) -> int:
+        return self._data["upUnit"]
+
+class OmadaClientDetails(OmadaConnectedClient):
+
+    @property
+    def device_category(self) -> Optional[str]:
+        return self._data.get("deviceCategory")
+    
+    @property
+    def ip_setting(self) -> IpSetting:
+        return IpSetting(self._data["ipSetting"])
+
+    @property
+    def os_name(self) -> Optional[str]:
+        return self._data.get("osName")
+
+    @property
+    def rate_limit(self) -> RateLimit:
+        return RateLimit(self._data["rateLimit"])
+
+    @property
+    def vendor(self) -> Optional[str]:
+        return self._data.get("vendor")
+    
+
+
+class OmadaWiredClient(OmadaConnectedClient):
+
+    @property
+    def dot1xVlan(self) -> int:
+        """ Network name corresponding to the VLAN obtained by 802.1x D-VLAN """
+        return self._data["dot1xVlan"]
+
+    @property
+    def gateway_mac(self) -> Optional[str]:
+        """ Mac address of gateway the client is connected to """
+        return self._data.get("switchMac")
+
+    @property
+    def gateway_name(self) -> Optional[str]:
+        return self._data.get("gatewayName")
+
+    @property
+    def network_name(self) -> str:
+        """ Network name """
+        return self._data["networkName"]
+
+    @property
+    def port(self) -> int:
+        """ Switch port client is connected to """
+        return self._data["port"]
+
+    @property
+    def switch_mac(self) -> Optional[str]:
+        """ Mac address of switch the client is connected to """
+        return self._data.get("switchMac")
+
+    @property
+    def switch_name(self) -> Optional[str]:
+        """ Name of switch the client is connected to """
+        return self._data.get("switchName")
+
+class OmadaWiredClientDetails(OmadaWiredClient, OmadaClientDetails):
+    pass
+
+class OmadaWirelessClient(OmadaConnectedClient):
+
+    @property
+    def ap_mac(self) -> str:
+        """ Access point mac address """
+        return self._data["apMac"]
+
+    @property
+    def ap_name(self) -> str:
+        """ Access point name """
+        return self._data["apName"]
+
+    @property
+    def channel(self) -> int:
+        return self._data["channel"]
+
+    @property
+    def is_power_save(self) -> bool:
+        """ Indicates if power save mode is enabled """
+        return self._data["powerSave"]
+
+    @property
+    def radio_id(self) -> RadioId:
+        """ Radio frequency id """
+        return self._data["radioId"]
+
+    @property
+    def rssi(self) -> int:
+        """ Signal strength in dBm """
+        return self._data["rssi"]
+
+    @property
+    def rx_rate(self) -> int:
+        """ Uplink negotiation rate in Kbit/s """
+        return self._data["rxRate"]
+
+    @property
+    def signal_level(self) -> int:
+        """ Signal strength percentage """
+        return self._data["signalLevel"]
+
+    @property
+    def signal_rank(self) -> int:
+        """ Signal strength (0-5) """
+        return self._data["signalRank"]
+
+    @property
+    def ssid(self) -> str:
+        """ SSID name """
+        return self._data["ssid"]
+
+    @property
+    def tx_rate(self) -> int:
+        """ Downlink negotiation rate (Kbit/s) """
+        return self._data["txRate"]
+
+    @property
+    def wifi_mode(self) -> WifiMode:
+        """ WiFi mode """
+        return self._data["wifiMode"]
+
+class OmadaWirelessClientDetails(OmadaWirelessClient, OmadaClientDetails):
+    pass

--- a/src/tplink_omada_client/definitions.py
+++ b/src/tplink_omada_client/definitions.py
@@ -1,7 +1,28 @@
 """ Definitions for Omada enums. """
 
+from abc import ABC
 from enum import IntEnum
+from typing import Any
 
+class OmadaApiData(ABC):
+    def __init__(self, data: dict[str, Any]):
+        self._data = data
+
+    def __repr__(self) -> str:
+        repr = self.__class__.__name__
+        repr += "{"
+        for name in self.__dir__():
+            if (
+                not name.startswith("_")
+                and name != "raw_data"
+            ):
+                repr += f"{name}={getattr(self, name)},"
+        repr += "}"
+        return repr
+
+    @property
+    def raw_data(self) -> dict[str, Any]:
+        return self._data
 
 class DeviceStatus(IntEnum):
     """Known status codes for devices."""
@@ -110,3 +131,34 @@ class PoEMode(IntEnum):
     DISABLED = 0
     ENABLED = 1
     USE_DEVICE_SETTINGS = 2
+
+class AuthenticationStatus:
+    """ Client authentication status. """
+    CONNECTED = 0
+    PENDING = 1
+    AUTHORIZED = 2
+    AUTH_FREE = 3
+
+class ConnectType(IntEnum):
+    """ Client connection types. """
+    GUEST_WIRELESS = 0
+    WIRELESS = 1
+    WIRED = 2
+
+class RadioId(IntEnum):
+    """ WiFi radio frequencies """
+    FREQ_2_4 = 0
+    FREQ_5_1 = 1
+    FREQ_5_2 = 2
+    FREQ_6   = 3
+
+class WifiMode(IntEnum):
+    """ WiFi modes. """
+    A   = 0
+    B   = 1
+    G   = 2
+    NA  = 3
+    NG  = 4
+    AC  = 5
+    AXA = 6
+    AXG = 7

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -14,19 +14,10 @@ from .definitions import (
     LinkDuplex,
     LinkSpeed,
     LinkStatus,
+    OmadaApiData,
     PoEMode,
     PortType,
 )
-
-
-class OmadaApiData:
-    def __init__(self, data: dict[str, Any]):
-        self._data = data
-
-    @property
-    def raw_data(self) -> dict[str, Any]:
-        return self._data
-
 
 class OmadaDevice(OmadaApiData):
     """Details of a device connected to the controller"""


### PR DESCRIPTION
This adds support for the Omada client API. It has support for connected clients, known clients (clients Omada has seen but may not be connected), getting client details, blocking and unblocking.

There are some changes that are just alphabetizing method declarations and/or imports.

I moved the `OmadaApiData` class to 'definitions.py' but this doesn't seem like the right home for it. I'm open to suggestions. 