### PR TITLE
Fix link speeds enum

### DIFF
--- a/src/tplink_omada_client/definitions.py
+++ b/src/tplink_omada_client/definitions.py
@@ -97,7 +97,8 @@ class LinkSpeed(IntEnum):
     SPEED_10_MBPS = 1
     SPEED_100_MBPS = 2
     SPEED_1_GBPS = 3
-    SPEED_10_GBPS = 4
+    SPEED_2_5_GBPS = 4
+    SPEED_10_GBPS = 5
 
 
 class LinkDuplex(IntEnum):


### PR DESCRIPTION
It appears the documentation is in error when it says that link speed 4 is 10 Gbps. I have a TL-SG3210XHP-M2 with 8 2.5 Gbps ports and 2 10 Gbps SFP+ ports. The `switch_ports` CLI command reports the max speed of the 2.5 Gbps ports as 'SPEED_10_GBPS' and errors on the SFP+ ports saying that '5' is not a valid value for `LinkSpeed`.

I also have a TL-SX3016F switch with 16 SFP+ 10 Gbps ports which fails.

This commit fixes the issues with both switches.