### PR TITLE
Fallback if upgrade flags are not available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
   { name="Mark Godwin", email="author@example.com" },
 ]

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -105,7 +105,7 @@ class OmadaListDevice(OmadaDevice):
     def need_upgrade(self) -> bool:
         """True, if a firmware upgrade is available for the device."""
         if self._data["statusCategory"] == DeviceStatusCategory.CONNECTED:
-            return self._data["needUpgrade"]
+            return self._data.get("needUpgrade", False)
         else:
             return False
 
@@ -113,7 +113,7 @@ class OmadaListDevice(OmadaDevice):
     def fw_download(self) -> bool:
         """True, if a firmware upgrade is being downloaded."""
         if self._data["statusCategory"] == DeviceStatusCategory.CONNECTED:
-            return self._data["fwDownload"]
+            return self._data.get("fwDownload", False)
         else:
             return False
 


### PR DESCRIPTION
Tiny change to avoid crashing out if the firmware update properties are missing from the API data. This appears to happen during Omada device reboots.