### PR TITLE
Bugfix/32 clientlist

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,6 +51,14 @@
             "module": "tplink_omada_client.cli",
             "justMyCode": true,
             "args": ["gateway", "--dump"]
+        },
+        {
+            "name": "CLI: Get Clients",
+            "type": "python",
+            "request": "launch",
+            "module": "tplink_omada_client.cli",
+            "justMyCode": true,
+            "args": ["clients"]
         }
 
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.3.6"
+version = "1.3.7"
 authors = [
   { name="Mark Godwin", email="author@example.com" },
 ]

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -122,7 +122,7 @@ class OmadaSiteClient:
 
     async def get_connected_clients(self) -> AsyncIterable[OmadaConnectedClient]:
         """Get the clients connected to the site network."""
-        async for client in self._api.iterate_pages(self._api.format_url("clients", self._site_id)):
+        async for client in self._api.iterate_pages(self._api.format_url("clients", self._site_id), {"filters.active": "false"}):
             if client["wireless"]:
                 yield OmadaWirelessClient(client)
             else:


### PR DESCRIPTION
For some reason, the clients API sometimes fails if there is no "filters.active" parameter set in the request. `false` seems to work about as well as `true`.