### PR TITLE
Improved target command line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.3.7"
+version = "1.3.8"
 authors = [
   { name="Mark Godwin", email="author@example.com" },
 ]

--- a/src/tplink_omada_client/cli/command_target.py
+++ b/src/tplink_omada_client/cli/command_target.py
@@ -1,9 +1,8 @@
 """Implementation of 'target' command"""
 from argparse import _SubParsersAction, ArgumentError
 import getpass
-import json
 
-from tplink_omada_client.exceptions import ConnectionFailed, OmadaClientException
+from tplink_omada_client.exceptions import OmadaClientException
 
 from .util import get_target_argument, assert_target_argument
 from .config import ControllerConfig, delete_target_config, get_target_config, set_target_config, to_omada_connection

--- a/src/tplink_omada_client/cli/command_targets.py
+++ b/src/tplink_omada_client/cli/command_targets.py
@@ -8,8 +8,8 @@ from .config import (
 async def command_targets(args) -> int: # pylint: disable=unused-argument
     """Executes 'targets' command"""
     controllers = get_targets()
-    for (controller, url, is_default) in controllers:
-        print(f"{('*' if is_default else' ')} {controller:15} {url}")
+    for (controller, config, is_default) in controllers:
+        print(f"{('*' if is_default else' ')} {controller:15} {config.url:30} Site: {config.site:15} Username: {config.username}")
     return 0
 
 def arg_parser(subparsers: _SubParsersAction) -> None:

--- a/src/tplink_omada_client/cli/config.py
+++ b/src/tplink_omada_client/cli/config.py
@@ -18,7 +18,7 @@ class ControllerConfig:
     password: str
     site: str
 
-def get_targets() -> list[tuple[str, str, bool]]:
+def get_targets() -> list[tuple[str, ControllerConfig, bool]]:
     """Get all the controllers in config file"""
     config_parser = _read_config_file()
     default_target = config_parser[_CLI_SECTION][_DEFAULT_TARGET] if _CLI_SECTION in config_parser else ""
@@ -26,7 +26,7 @@ def get_targets() -> list[tuple[str, str, bool]]:
     for (target, config) in config_parser.items():
         if target.startswith(_CONTROLLER_SECTION_PREFIX):
             name = target[len(_CONTROLLER_SECTION_PREFIX):]
-            targets.append((name, config["url"], name == default_target))
+            targets.append((name, ControllerConfig(**config), name == default_target))
     return targets
 
 def get_target_config(name: str) -> ControllerConfig:
@@ -68,6 +68,13 @@ def set_default_target(name: str) -> None:
         config_parser[_CLI_SECTION] = {}
     config_parser[_CLI_SECTION][_DEFAULT_TARGET] = name
     _write_config_file(config_parser)
+
+def delete_target_config(name: str) -> None:
+    config = _read_config_file()
+    stored_name = _to_stored_name(name)
+    if config.has_section(stored_name):
+        config.remove_section(stored_name)
+        _write_config_file(config)
 
 def to_omada_connection(config: ControllerConfig) -> OmadaClient:
     """Create a OmadaClient based on a ControllerConfig object"""

--- a/src/tplink_omada_client/cli/util.py
+++ b/src/tplink_omada_client/cli/util.py
@@ -13,7 +13,7 @@ TARGET_ARG: str = "target"
 def assert_target_argument(args: dict[str, Any]) -> str:
     """Throws ArgumentError if target arg missing"""
     if args[TARGET_ARG] == "": # The default is now empty
-        raise argparse.ArgumentError(None, f"error: Missing --{TARGET_ARG} argument")
+        raise argparse.ArgumentError(None, f"error: Target name must be supplied using --{TARGET_ARG} argument")
     return args[TARGET_ARG]
 
 def get_target_argument(args: dict[str, Any]) -> str:


### PR DESCRIPTION
The `target` cli command line was a bit hard to use, and missing some features.
Now we can:
 - prevent targets with no no names being created
 - allow deletion of targets
 - allow update of existing targets without specifying all parameters