### PR TITLE
Allow CLI to skip SSL verification

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,14 @@
             "args": ["targets"]
         },
         {
+            "name": "CLI: Update Target",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "tplink_omada_client.cli",
+            "justMyCode": true,
+            "args": ["--target", "OC200b", "target", "--no-verify-ssl"]
+        },
+        {
             "name": "CLI: List Switches",
             "type": "debugpy",
             "request": "launch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.3.10"
+version = "1.3.11"
 authors = [
   { name="Mark Godwin", email="author@example.com" },
 ]

--- a/src/tplink_omada_client/cli/command_targets.py
+++ b/src/tplink_omada_client/cli/command_targets.py
@@ -9,7 +9,7 @@ async def command_targets(args) -> int: # pylint: disable=unused-argument
     """Executes 'targets' command"""
     controllers = get_targets()
     for (controller, config, is_default) in controllers:
-        print(f"{('*' if is_default else' ')} {controller:15} {config.url:30} Site: {config.site:15} Username: {config.username}")
+        print(f"{('*' if is_default else' ')} {controller:15} {config.url:30} Site: {config.site:15} Username: {config.username}  Verify SSL: {config.verify_ssl}")
     return 0
 
 def arg_parser(subparsers: _SubParsersAction) -> None:


### PR DESCRIPTION
Newer versions of python are more picky about SSL certificates.
Add a CLI option to ignore SSL verification problems.