### PR TITLE
Add PoE control on gateways and PoE cli command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -69,6 +69,14 @@
             "args": ["wan", "--port", "2"]
         },
         {
+            "name": "CLI: Set Port Port PoE",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "tplink_omada_client.cli",
+            "justMyCode": true,
+            "args": ["poe", "Main Switch", "--port", "2", "--on", "-d"]
+        },
+        {
             "name": "CLI: Get Clients",
             "type": "debugpy",
             "request": "launch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.3.11"
+version = "1.3.12"
 authors = [
   { name="Mark Godwin", email="author@example.com" },
 ]

--- a/src/tplink_omada_client/cli/__init__.py
+++ b/src/tplink_omada_client/cli/__init__.py
@@ -24,8 +24,8 @@ from . import (
     command_unblock_client,
     command_set_device_led,
     command_set_client_name,
-    command_wan
-
+    command_wan,
+    command_poe
 )
 
 def main(argv: Union[Sequence[str], None] = None) -> int:
@@ -62,6 +62,7 @@ def main(argv: Union[Sequence[str], None] = None) -> int:
     command_set_device_led.arg_parser(subparsers)
     command_set_client_name.arg_parser(subparsers)
     command_wan.arg_parser(subparsers)
+    command_poe.arg_parser(subparsers)
 
     try:
         args = parser.parse_args(args=argv)

--- a/src/tplink_omada_client/cli/command_poe.py
+++ b/src/tplink_omada_client/cli/command_poe.py
@@ -1,0 +1,89 @@
+"""Implementation for 'poe' command"""
+
+from argparse import ArgumentError, ArgumentParser
+
+from tplink_omada_client.definitions import OmadaApiData, PoEMode
+from tplink_omada_client.devices import OmadaDevice
+from tplink_omada_client.omadasiteclient import AccessPointPortSettings, GatewayPortSettings, OmadaSiteClient, SwitchPortOverrides
+
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_device_by_mac_or_name, get_target_argument
+
+async def set_gateway_poe(site_client: OmadaSiteClient, device: OmadaDevice, port: int, change: bool, on: bool) -> OmadaApiData:
+    if change:
+        result = await site_client.set_gateway_port_settings(port, GatewayPortSettings(enable_poe=on), device)
+    else:
+        result = await site_client.get_gateway_port(port, device)
+    print(f"Gateway {device.name} Port {port} PoE is {result.poe_mode.name}")
+    return result
+
+async def set_switch_poe(site_client: OmadaSiteClient, device: OmadaDevice, port: int, change: bool, on: bool) -> OmadaApiData:
+    if change:
+        result = await site_client.update_switch_port(device, port, overrides=SwitchPortOverrides(enable_poe=on))
+    else:
+        result = await site_client.get_switch_port(device, port)
+    print(f"Switch {device.name} Port {port} PoE now is {result.poe_mode.name}")
+    return result
+
+async def set_access_point_poe(site_client: OmadaSiteClient, device: OmadaDevice, port: int, change: bool, on: bool) -> OmadaApiData:
+    if change:
+        result = await site_client.update_access_point_port(device, f"ETH{port}", AccessPointPortSettings(enable_poe=on))
+    else:
+        result = await site_client.get_access_point_port(device, f"ETH{port}")
+    print(f"Access point {device.name} Port {result.port_name} PoE is {(PoEMode.ENABLED if result.poe_enable else (PoEMode.DISABLED if result.supports_poe else PoEMode.NONE)).name}")
+    return result
+
+async def command_poe(args) -> int:
+    """Executes 'poe' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        device = await get_device_by_mac_or_name(site_client, args['mac'])
+
+        port = int(args['port'])
+        change = args['on'] or args['off']
+        on = bool(args['on'])
+
+        handlers = {"gateway": set_gateway_poe, "switch": set_switch_poe, "ap": set_access_point_poe}
+        handler = handlers.get(device.type)
+        if not handler:
+            raise ArgumentError(args["mac"], "Device type not supported")
+        
+        result = await handler(site_client, device, port, change, on)
+        dump_raw_data(args, result)
+
+    return 0
+
+def arg_parser(subparsers) -> None:
+    """Configures arguments parser for 'poe' command"""
+    switch_parser: ArgumentParser = subparsers.add_parser(
+        "poe",
+        help="Controls a device's PoE ports"
+    )
+    switch_parser.set_defaults(func=command_poe)
+
+    switch_parser.add_argument(
+        "mac",
+        help="The MAC address or name of the gateway, switch or access point with PoE ports"
+    )
+    switch_parser.add_argument(
+        "-p", "--port",
+        help="The port number on the device to set the PoE state.",
+        required=True
+    )
+
+    con_discon_grp = switch_parser.add_mutually_exclusive_group()
+    con_discon_grp.add_argument(
+        "--on",
+        help="Turn PoE On",
+        action="store_true"
+    )
+    con_discon_grp.add_argument(
+        "--off",
+        help="Turn PoE Off",
+        action="store_true"        
+    )
+    switch_parser.add_argument('-d', '--dump', help="Output raw port information",  action='store_true')
+

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -795,6 +795,15 @@ class OmadaGateway(OmadaDetailedDevice):
         return [
             OmadaGatewayPortConfig(p, poeData.get(p["port"])) for p in self._data["portConfigs"]
         ]
+    
+    @property
+    def lldp_enabled(self) -> bool:
+        """LLDP Enabled for the whole gateway"""
+        return self._data.get("lldpEnable", False)
+    
+    @property
+    def echo_server(self) -> Union[str, None]:
+        return self._data.get("echoServer")
 
     @property
     def is_combined_gateway(self) -> bool:


### PR DESCRIPTION
Thanks to @dkriegner, we now know what the API looks like to control PoE settings on gateway ports (e.g. ER7212PC).

This change adds a function to modify the setting on a one gateway port at a time, to match the API for switches. This might not be the most efficient way if we want to control lots of ports at the same time, but it fits the HA use case of having a toggle switch for each port.

I've also added a `poe` command line mode that allows PoE control and state reporting for gateways, switches and access points.