### PR TITLE
Add methods to retrieve and change verify_ssl_switch

### DIFF
--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -234,3 +234,13 @@ class OmadaApiConnection:
         if response["errorCode"] == -30109:
             raise LoginFailed(response["errorCode"], response["msg"])
         raise RequestFailed(response["errorCode"], response["msg"])
+
+
+    def get_verify_ssl_switch(self):
+        """Return the verify_ssl switch."""
+        return self._verify_ssl
+    
+    def set_verify_ssl_switch(self, verify_ssl: bool):
+        """Set the verify_ssl switch."""
+        self._verify_ssl = verify_ssl
+        return self._verify_ssl

--- a/src/tplink_omada_client/omadaclient.py
+++ b/src/tplink_omada_client/omadaclient.py
@@ -92,3 +92,11 @@ class OmadaClient:
             return site_id
 
         raise SiteNotFound(f"Site '{site_name}' not found")
+    
+    def get_verify_ssl_switch(self) -> bool:
+        """Get the verify_ssl setting."""
+        return self._api.get_verify_ssl_switch()
+    
+    def set_verify_ssl_switch(self, verify_ssl: bool) -> None:
+        """Set the verify_ssl setting."""
+        self._api.set_verify_ssl_switch(verify_ssl)


### PR DESCRIPTION
To facilitate dynamic control of SSL Verify, once an integration has already been added into home assistant, added new methods in the following files:

omadaapiconnecttion.py

get_verify_ssl_switch() -> Bool :  retrieves current state of 'verify_ssl' class property
set_verify_ssl_switch(bool) -> None :  sets 'verify_ssl' class property

omadaclient.py

get_verify_ssl_switch() -> Bool :  Wrapper function for apiconnection
set_verify_ssl_switch(Bool) -> None :  Wrapper function for apiconnection

Next steps: Once merged, add method in HomeAssistant core Omada integration to show and modify the state from integration settings
