### PR TITLE
Make VLAN ID optional to support EAP245

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
   { name="Mark Godwin", email="author@example.com" },
 ]

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -362,17 +362,17 @@ class OmadaAccesPointLanPortSettings(OmadaApiData):
     @property
     def local_vlan_enable(self) -> bool:
         """True if VLAN tagging is enabled for the port explicitly"""
-        return self._data["localVlanEnable"]
+        return self._data.get("localVlanEnable", False)
 
     @property
     def local_vlan_id(self) -> int:
         """VLAN ID for this port"""
-        return self._data["localVlanId"]
+        return self._data.get("localVlanId", -1)
 
     @property
     def supports_poe(self) -> bool:
         """True if the port supports PoE output"""
-        return self._data["supportPoe"]
+        return self._data.get("supportPoe", False)
 
     @property
     def poe_enable(self) -> bool:


### PR DESCRIPTION
Add defaults for missing VLan IDs and PoE settings for access points.