### PR TITLE
Ignore known clients with missing wireless parameter.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.4.1"
+version = "1.4.2"
 authors = [
   { name="Mark Godwin", email="author@example.com" },
 ]

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -181,17 +181,19 @@ class OmadaSiteClient:
         async for client in self._api.iterate_pages(
             self._api.format_url("clients", self._site_id), {"filters.active": "false"}
         ):
-            if client["wireless"]:
+            is_wireless = client.get("wireless")
+            if is_wireless:
                 yield OmadaWirelessClient(client)
-            else:
+            elif is_wireless is False:
                 yield OmadaWiredClient(client)
 
     async def get_known_clients(self) -> AsyncIterable[OmadaNetworkClient]:
         """Get the clients connected to the site network."""
         async for client in self._api.iterate_pages(self._api.format_url("insight/clients", self._site_id)):
-            if client["wireless"]:
+            is_wireless = client.get("wireless")
+            if is_wireless:
                 yield OmadaWirelessClient(client)
-            else:
+            elif is_wireless is False:
                 yield OmadaWiredClient(client)
 
     async def get_devices(self) -> list[OmadaListDevice]:


### PR DESCRIPTION
Apparently clients that have never been connected but have IP addresses reserved will not present a "wireless" parameter. We now ignore these devices when enumerating them.