### PR TITLE
memUtil doesnt exists on some gateway devices outputs

### DIFF
--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -92,7 +92,7 @@ class OmadaDevice(OmadaApiData):
     def mem_usage(self) -> int:
         """Current memory usage of the device."""
         if self._data["statusCategory"] == DeviceStatusCategory.CONNECTED:
-            return self._data["memUtil"]
+            return self._data.get("memUtil", 0)
         else:
             return 0
 


### PR DESCRIPTION
On some devices memUtil doesnt exists in output from device so if such key doesnt exists we assuming it is 0.

For example on ER7212PC we have output:
```sh
# omada  devices -d
........
00-00-00-00-00-00       10.0.0.1 gateway CONNECTED        Router               ER7212PC v1.0
--- BEGIN RAW DATA ---
{
  "type": "gateway",
  "subDevType": 0,
  "mac": "00-00-00-00-00-00",
  "name": "Router",
  "model": "ER7212PC",
  "compoundModel": "ER7212PC v1.0",
  "showModel": "ER7212PC v1.0",
  "modelVersion": "1.0",
  "firmwareVersion": "1.2.0 Build 20240716 Rel.80083",
  "version": "1.2.0",
  "hwVersion": "ER7212PC v1.0",
  "ip": "10.0.0.1",
  "publicIp": "127.0.0.1",
  "uptime": "6h 51m 12s",
  "uptimeLong": 24672,
  "statusCategory": 1,
  "status": 14,
  "adoptFailType": -1,
  "lastSeen": 1736259318388,
  "needUpgrade": false,
  "fwDownload": false,
  "cpuUtil": 7,
  "download": 5630386359,
  "upload": 1511366459,
  "site": "999999999999999999999999999999",
  "clientNum": 6,
  "compatible": 0,
  "locateEnable": false,
  "sn": "9999999999999",
  "combinedGateway": true,
  "category": "PRO GATEWAY",
  "licenseStatusStr": "-"
}
---  END RAW DATA  ---
........

```



It is related to https://github.com/home-assistant/core/issues/134973