### PR TITLE
Fix #59 - Iterating result pages misses last page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.4.3"
+version = "1.4.4"
 authors = [
   { name="Mark Godwin", email="10632972+MarkGodwin@users.noreply.github.com" },
 ]

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -84,7 +84,7 @@ class OmadaDevice(OmadaApiData):
     def cpu_usage(self) -> int:
         """Currenct CPU usage of the device."""
         if self._data["statusCategory"] == DeviceStatusCategory.CONNECTED:
-            return self._data["cpuUtil"]
+            return self._data.get("cpuUtil", 0)
         else:
             return 0
 

--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -142,19 +142,20 @@ class OmadaApiConnection:
         request_params = {}
         if params is not None:
             request_params.update(params)
-        request_params["currentPageSize"] = _PAGE_SIZE
+        actual_page_size = _PAGE_SIZE
 
         current_page = 1
         has_next = True
         while has_next:
+            request_params["currentPageSize"] = actual_page_size
             request_params["currentPage"] = current_page
             response = await self.request("get", url, request_params)
 
             # Setup next page request
-            current_page = int(response["currentPage"]) + 1
-            current_size = int(response["currentSize"])
+            actual_page_size = int(response["currentSize"])
             total_rows = int(response["totalRows"])
-            has_next = total_rows > current_page * current_size
+            has_next = total_rows > current_page * actual_page_size
+            current_page += 1
 
             data: list[dict[str, Any]] = response["data"]
             for item in data:


### PR DESCRIPTION
The final page of results was being skipped due to a simple logic error.
Also added a default for `cpuUtil` along the lines of `memUtil`, in case it is missing from any devices.

Thanks @DavidvtWout