### PR TITLE
Expose supports_poe for switch ports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
   { name="Mark Godwin", email="10632972+MarkGodwin@users.noreply.github.com" },
 ]

--- a/src/tplink_omada_client/cli/command_switch_ports.py
+++ b/src/tplink_omada_client/cli/command_switch_ports.py
@@ -40,7 +40,7 @@ async def command_switch_ports(args) -> int:
                 print(f"    Profile:     {p.profile_name} - {get_checkbox_char(p.has_profile_override)}")
                 print(f"    Enabled:     {get_checkbox_char(not p.is_disabled)}")
                 print(f"    Status:      {get_link_status_char(p.port_status.link_status)} ")
-                if switch.device_capabilities.supports_poe and p.type != PortType.SFP:
+                if switch.device_capabilities.supports_poe and p.supports_poe and p.type != PortType.SFP:
                     print(f"    PoE:         {get_checkbox_char(p.poe_mode == PoEMode.ENABLED)} ", end="")
                     print(f"{get_power_char(p.port_status.poe_active)} {p.port_status.poe_power}W ")
                 else:
@@ -66,7 +66,7 @@ def _print_port_table(switch: OmadaSwitch, ports: list[OmadaSwitchPortDetails]):
         else:
             print("       --- ", end="")
 
-        if switch.device_capabilities.supports_poe and p.type != PortType.SFP:
+        if switch.device_capabilities.supports_poe and p.supports_poe and p.type != PortType.SFP:
             print(f" {get_checkbox_char(p.poe_mode == PoEMode.ENABLED)}", end="")
             print(f"{get_power_char(p.port_status.poe_active)} {p.port_status.poe_power:>4}W ", end="")
         else:

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -385,7 +385,7 @@ class OmadaAccesPointLanPortSettings(OmadaApiData):
 
         WARNING: Do not enable PoE for EAPs powered from another EAP
         """
-        return self._data["poeOutEnable"]
+        return self._data.get("poeOutEnable", False)
 
 
 class OmadaAccessPoint(OmadaDetailedDevice):
@@ -479,9 +479,15 @@ class OmadaSwitchPortDetails(OmadaSwitchPort):
         return self._data["profileOverrideEnable"]
 
     @property
+    def supports_poe(self) -> bool:
+        """True if the port supports PoE."""
+        return self._data.get("supportPoe", True)  # default to true, some older versions don't report this
+
+    @property
     def poe_mode(self) -> PoEMode:
         """PoE config for this port."""
-        return PoEMode(self._data.get("poe", PoEMode.NONE))
+        # For reasons, Omada may claim Enabled on non-poe ports - probably due to port profiles
+        return PoEMode(self._data.get("poe", PoEMode.NONE)) if self.supports_poe else PoEMode.NONE
 
     @property
     def bandwidth_limit_mode(self) -> BandwidthControl:


### PR DESCRIPTION
Omada now has a property on the switch port list that describes POE availability.
For older software versions, this may report "true", so you need to pay attention to whether the switch itself also claims PoE support.