### PR TITLE
Correctly export symbols

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.5.2"
+version = "1.5.3"
 authors = [
   { name="Mark Godwin", email="10632972+MarkGodwin@users.noreply.github.com" },
 ]

--- a/src/tplink_omada_client/__init__.py
+++ b/src/tplink_omada_client/__init__.py
@@ -3,12 +3,13 @@
 from .devices import OmadaSwitchPortDetails
 from .omadaclient import OmadaClient, OmadaSite
 from .omadasiteclient import (
-    OmadaSiteClient,
-    PortProfileOverrides,
     AccessPointPortSettings,
     GatewayPortSettings,
     OmadaClientSettings,
     OmadaClientFixedAddress,
+    OmadaSiteClient,
+    PortProfileOverrides,
+    SwitchPortSettings,
 )
 from . import definitions
 from . import exceptions
@@ -23,6 +24,7 @@ __all__ = [
     "OmadaClientSettings",
     "OmadaClientFixedAddress",
     "PortProfileOverrides",
+    "SwitchPortSettings",
     "OmadaSwitchPortDetails",
     "definitions",
     "exceptions",

--- a/src/tplink_omada_client/cli/command_client.py
+++ b/src/tplink_omada_client/cli/command_client.py
@@ -3,7 +3,7 @@
 from argparse import _SubParsersAction, ArgumentError
 import datetime
 from tplink_omada_client.clients import OmadaConnectedClient, OmadaWiredClientDetails, OmadaWirelessClientDetails
-from tplink_omada_client.omadasiteclient import OmadaClientFixedAddress, OmadaClientSettings
+from tplink_omada_client import OmadaClientFixedAddress, OmadaClientSettings
 from .config import get_target_config, to_omada_connection
 from .util import dump_raw_data, get_client_mac, get_target_argument
 

--- a/src/tplink_omada_client/cli/command_poe.py
+++ b/src/tplink_omada_client/cli/command_poe.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentError, ArgumentParser
 from tplink_omada_client.definitions import OmadaApiData, PoEMode
 from tplink_omada_client.devices import OmadaDevice
-from tplink_omada_client.omadasiteclient import (
+from tplink_omada_client import (
     AccessPointPortSettings,
     GatewayPortSettings,
     OmadaSiteClient,

--- a/src/tplink_omada_client/cli/command_set_client_name.py
+++ b/src/tplink_omada_client/cli/command_set_client_name.py
@@ -2,7 +2,7 @@
 
 from argparse import _SubParsersAction
 from tplink_omada_client.cli.command_client import print_client
-from tplink_omada_client.omadasiteclient import OmadaClientSettings
+from tplink_omada_client import OmadaClientSettings
 from .config import get_target_config, to_omada_connection
 from .util import dump_raw_data, get_client_mac, get_target_argument
 


### PR DESCRIPTION
New `SwitchPortSettings` object needs to be exported from the public namespace