### PR TITLE
Fix clients API for Omada 6.2.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Only a subset of the controller's features are supported:
     * Lan port configuration for Access Points
     * Gateway port status and WAN port Connect/Disconnect control
 
-Tested with OC200 on Omada Controller Version 5.5.7 - 5.12.x. Other versions may not be fully compatible.
+Tested with OC200 on Omada Controller Version 5.5.7 - 6.2.x. Other versions may not be fully compatible.
 Version 5.0.x is definitely not compatible.
 
 ## CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.5.5"
+version = "1.5.6"
 authors = [
   { name="Mark Godwin", email="10632972+MarkGodwin@users.noreply.github.com" },
 ]

--- a/src/tplink_omada_client/clients.py
+++ b/src/tplink_omada_client/clients.py
@@ -213,7 +213,7 @@ class OmadaWiredClient(OmadaConnectedClient):
     @property
     def dot1x_vlan(self) -> int:
         """Network name corresponding to the VLAN obtained by 802.1x D-VLAN"""
-        return self._data["dot1xVlan"]
+        return self._data.get("dot1xVlan", 0)
 
     @property
     def gateway_mac(self) -> str | None:
@@ -233,7 +233,7 @@ class OmadaWiredClient(OmadaConnectedClient):
     @property
     def port(self) -> int:
         """Switch port client is connected to"""
-        return self._data["port"]
+        return self._data.get("port", -1)
 
     @property
     def switch_mac(self) -> str | None:

--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -137,16 +137,16 @@ class OmadaApiConnection:
 
         return urljoin(self._url, f"/{self._controller_id}/api/v2/{end_point}")
 
-    def format_openapi_url(self, end_point: str, site: str | None = None) -> str:
+    def format_openapi_url(self, end_point: str, version: str = "v1", site: str | None = None) -> str:
         """Get a REST url for the controller action"""
 
         if site:
             end_point = f"/sites/{site}/{end_point}"
 
-        return urljoin(self._url, f"/openapi/v1/{self._controller_id}{end_point}")
+        return urljoin(self._url, f"/openapi/{version}/{self._controller_id}{end_point}")
 
     async def iterate_pages(self, url: str, params: dict[str, Any] | None = None) -> AsyncIterable[dict[str, Any]]:
-        """Iterates all the entries of a paged endpoint"""
+        """Iterates all the entries of a paged endpoint using GET with query parameters (old API)"""
         request_params = {}
         if params is not None:
             request_params.update(params)
@@ -158,6 +158,30 @@ class OmadaApiConnection:
             request_params["currentPageSize"] = actual_page_size
             request_params["currentPage"] = current_page
             response = await self.request("get", url, request_params)
+
+            # Setup next page request
+            actual_page_size = int(response["currentSize"])
+            total_rows = int(response["totalRows"])
+            has_next = total_rows > current_page * actual_page_size
+            current_page += 1
+
+            data: list[dict[str, Any]] = response["data"]
+            for item in data:
+                yield item
+
+    async def iterate_pages_openapi(self, url: str, body: dict[str, Any] | None = None) -> AsyncIterable[dict[str, Any]]:
+        """Iterates all the entries of a paged endpoint using POST with JSON body (OpenAPI v2)"""
+        request_body = {}
+        if body is not None:
+            request_body.update(body)
+        actual_page_size = _PAGE_SIZE
+
+        current_page = 1
+        has_next = True
+        while has_next:
+            request_body["pageSize"] = actual_page_size
+            request_body["page"] = current_page
+            response = await self.request("post", url, json=request_body)
 
             # Setup next page request
             actual_page_size = int(response["currentSize"])

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -218,12 +218,25 @@ class OmadaSiteClient:
 
     async def get_connected_clients(self) -> AsyncIterable[OmadaConnectedClient]:
         """Get the clients connected to the site network."""
-        async for client in self._api.iterate_pages(self._api.format_url("clients", self._site_id), {"filters.active": "false"}):
-            is_wireless = client.get("wireless")
-            if is_wireless:
-                yield OmadaWirelessClient(client)
-            elif is_wireless is False:
-                yield OmadaWiredClient(client)
+        if (await self._api.get_controller_version()) >= AwesomeVersion("6.2.0.0"):
+            request_url = self._api.format_openapi_url("clients", version="v2", site=self._site_id)
+            async for client in self._api.iterate_pages_openapi(
+                request_url,
+                body={"filters": {"active": True}, "sorts": {}, "hideHealthUnsupported": True, "scope": 1},
+            ):
+                is_wireless = client.get("wireless")
+                if is_wireless:
+                    yield OmadaWirelessClient(client)
+                elif is_wireless is False:
+                    yield OmadaWiredClient(client)
+        else:
+            request_url = self._api.format_url("clients", self._site_id)
+            async for client in self._api.iterate_pages(request_url, {"filters.active": "false"}):
+                is_wireless = client.get("wireless")
+                if is_wireless:
+                    yield OmadaWirelessClient(client)
+                elif is_wireless is False:
+                    yield OmadaWiredClient(client)
 
     async def get_known_clients(self) -> AsyncIterable[OmadaNetworkClient]:
         """Get the clients connected to the site network."""

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "tplink-omada-client"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Switch to OpenAPI V2 Clients API on controller 6.2 and later. Fixes #73 