### PR TITLE
Fix failure to update switch ports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.5.6"
+version = "1.5.7"
 authors = [
   { name="Mark Godwin", email="10632972+MarkGodwin@users.noreply.github.com" },
 ]

--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -141,9 +141,9 @@ class OmadaApiConnection:
         """Get a REST url for the controller action"""
 
         if site:
-            end_point = f"/sites/{site}/{end_point}"
+            end_point = f"sites/{site}/{end_point}"
 
-        return urljoin(self._url, f"/openapi/{version}/{self._controller_id}{end_point}")
+        return urljoin(self._url, f"/openapi/{version}/{self._controller_id}/{end_point}")
 
     async def iterate_pages(self, url: str, params: dict[str, Any] | None = None) -> AsyncIterable[dict[str, Any]]:
         """Iterates all the entries of a paged endpoint using GET with query parameters (old API)"""

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -551,7 +551,7 @@ class OmadaSiteClient:
         if (await self._api.get_controller_version()) < AwesomeVersion("6"):
             request_url = self._api.format_url(f"switches/{mac}/ports/{port.port}", self._site_id)
         else:
-            request_url = self._api.format_openapi_url(f"switches/{mac}/ports/{port.port}", self._site_id)
+            request_url = self._api.format_openapi_url(f"switches/{mac}/ports/{port.port}", site=self._site_id)
 
         await self._api.request(
             "patch",

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "tplink-omada-client"
-version = "1.5.6"
+version = "1.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
The site parameter had become the version parameter, making the URL invalid. Also fixed a future bug with non-site-specific URLs