### PR TITLE
Add controller info endpoint model (Related issue: #75)

### DIFF
--- a/src/tplink_omada_client/__init__.py
+++ b/src/tplink_omada_client/__init__.py
@@ -12,6 +12,7 @@ from .omadasiteclient import (
     SwitchPortSettings,
 )
 from .definitions import (
+    OmadaControllerInfo,
     OmadaControllerUpdateInfo,
     OmadaHardwareUpgradeStatus,
     OmadaHardwareUpdateInfo,
@@ -25,6 +26,7 @@ __all__ = [
     "OmadaClient",
     "OmadaSite",
     "OmadaSiteClient",
+    "OmadaControllerInfo",
     "OmadaControllerUpdateInfo",
     "OmadaHardwareUpgradeStatus",
     "OmadaHardwareUpdateInfo",

--- a/src/tplink_omada_client/cli/command_controller_info.py
+++ b/src/tplink_omada_client/cli/command_controller_info.py
@@ -1,9 +1,17 @@
 """Implementation for 'controller_info' command"""
 
 from argparse import ArgumentParser
+from typing import Any
 
 from .config import get_target_config, to_omada_connection
-from .util import get_target_argument
+from .util import dump_raw_data, get_target_argument
+
+
+def _format_value(value: Any) -> str:
+    """Format optional controller info values for CLI output."""
+    if value is None:
+        return "Unknown"
+    return str(value)
 
 
 async def command_controller_info(args) -> int:
@@ -12,8 +20,18 @@ async def command_controller_info(args) -> int:
     config = get_target_config(controller)
 
     conn = to_omada_connection(config)
-    ver = await conn.get_controller_version()  # We can get the version without a login
-    print(f"Controller version: {ver}")
+    info = await conn.get_controller_info()  # We can get controller info without a login
+    print(f"Controller version: {info.controller_version}")
+    print(f"API version: {_format_value(info.api_version)}")
+    print(f"Controller ID: {info.omadac_id}")
+    print(f"Controller type: {_format_value(info.type)}")
+    print(f"Controller category: {_format_value(info.omadac_category)}")
+    print(f"Configured: {_format_value(info.configured)}")
+    print(f"Root registered: {_format_value(info.registered_root)}")
+    print(f"Supports Omada app: {_format_value(info.support_app)}")
+    print(f"MSP mode: {_format_value(info.msp_mode)}")
+    print(f"Omada cloud URL: {_format_value(info.omada_cloud_url)}")
+    dump_raw_data(args, info)
 
     async with conn as client:
         name = await client.get_controller_name()
@@ -26,3 +44,4 @@ def arg_parser(subparsers) -> None:
     """Configures arguments parser for 'gateway' command"""
     parser: ArgumentParser = subparsers.add_parser("controller_info", help="Gets basic information about the Omada Controller")
     parser.set_defaults(func=command_controller_info)
+    parser.add_argument("-d", "--dump", help="Output raw controller information", action="store_true")

--- a/src/tplink_omada_client/definitions.py
+++ b/src/tplink_omada_client/definitions.py
@@ -26,6 +26,60 @@ class OmadaApiData(ABC):
         return self._data
 
 
+class OmadaControllerInfo(OmadaApiData):
+    """Information returned by the Omada Controller /api/info endpoint."""
+
+    @property
+    def controller_version(self) -> str:
+        """Controller software version."""
+        return self._data["controllerVer"]
+
+    @property
+    def api_version(self) -> str | None:
+        """Controller API version."""
+        return self._data.get("apiVer")
+
+    @property
+    def configured(self) -> bool | None:
+        """Whether the controller setup wizard has been completed."""
+        return self._data.get("configured")
+
+    @property
+    def type(self) -> int | None:
+        """Controller type as returned by the Omada API."""
+        return self._data.get("type")
+
+    @property
+    def support_app(self) -> bool | None:
+        """Whether the controller supports the Omada app."""
+        return self._data.get("supportApp")
+
+    @property
+    def omadac_id(self) -> str:
+        """Controller ID."""
+        return self._data["omadacId"]
+
+    @property
+    def registered_root(self) -> bool | None:
+        """Whether the root account is registered."""
+        return self._data.get("registeredRoot")
+
+    @property
+    def omadac_category(self) -> str | None:
+        """Controller category."""
+        return self._data.get("omadacCategory")
+
+    @property
+    def msp_mode(self) -> bool | None:
+        """Whether the controller is running in MSP mode."""
+        return self._data.get("mspMode")
+
+    @property
+    def omada_cloud_url(self) -> str | None:
+        """Omada cloud URL."""
+        return self._data.get("omadaCloudUrl")
+
+
 class DeviceStatus(IntEnum):
     """Known status codes for devices."""
 

--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -134,7 +134,6 @@ class OmadaApiConnection:
 
         return (info.controller_version, info.omadac_id)
 
-
     def format_url(self, end_point: str, site: str | None = None) -> str:
         """Get a REST url for the controller action"""
 

--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -9,6 +9,7 @@ from aiohttp import Payload, client_exceptions, CookieJar
 from aiohttp.client import ClientSession
 from awesomeversion import AwesomeVersion
 
+from .definitions import OmadaControllerInfo
 from .exceptions import (
     BadControllerUrl,
     ConnectionFailed,
@@ -122,12 +123,17 @@ class OmadaApiConnection:
         except:  # pylint: disable=bare-except  # noqa: E722
             return False
 
+    async def get_controller_info(self) -> OmadaControllerInfo:
+        """Get Omada controller diagnostic information unauthenticated."""
+        response = await self._do_request("get", urljoin(self._url, "/api/info"))
+        return OmadaControllerInfo(response)
+
     async def _get_controller_info(self) -> tuple[str, str]:
         """Get Omada controller version and Id (unauthenticated)."""
+        info = await self.get_controller_info()
 
-        response = await self._do_request("get", urljoin(self._url, "/api/info"))
+        return (info.controller_version, info.omadac_id)
 
-        return (response["controllerVer"], response["omadacId"])
 
     def format_url(self, end_point: str, site: str | None = None) -> str:
         """Get a REST url for the controller action"""

--- a/src/tplink_omada_client/omadaclient.py
+++ b/src/tplink_omada_client/omadaclient.py
@@ -7,7 +7,7 @@ from aiohttp.client import ClientSession
 from awesomeversion import AwesomeVersion
 from multidict import CIMultiDict
 
-from .definitions import OmadaControllerUpdateInfo, OmadaHardwareUpgradeStatus
+from .definitions import OmadaControllerInfo, OmadaControllerUpdateInfo, OmadaHardwareUpgradeStatus
 from .omadasiteclient import OmadaSiteClient
 from .omadaapiconnection import OmadaApiConnection
 
@@ -66,6 +66,10 @@ class OmadaClient:
     async def get_controller_version(self) -> AwesomeVersion:
         """Get the controller version as an AwesomeVersion object."""
         return await self._api.get_controller_version()
+
+    async def get_controller_info(self) -> OmadaControllerInfo:
+        """Get diagnostic information from the Omada Controller /api/info endpoint."""
+        return await self._api.get_controller_info()
 
     async def get_controller_name(self) -> str:
         """Get the display name of the Omada controller."""


### PR DESCRIPTION
Related issue: https://github.com/MarkGodwin/tplink-omada-api/issues/75

This PR exposes the diagnostic information returned by the Omada Controller `/api/info` endpoint as `OmadaControllerInfo`.

The library already uses `/api/info` internally to retrieve `controllerVer` and `omadacId`. This change keeps the existing `_get_controller_info()` behavior intact and adds a public `get_controller_info()` method exposing the remaining fields returned by the API.

Fields exposed:
- controllerVer
- apiVer
- configured
- type
- supportApp
- omadacId
- registeredRoot
- omadacCategory
- mspMode
- omadaCloudUrl

This is useful for consumers such as Home Assistant to represent the Omada Controller itself as a diagnostic entity.

The existing hardware controller firmware/update helpers are not changed.

Validated against Omada Software Controller 6.2.10.15.

Local validation:
- `git diff --check`
- `python -m compileall src`
- local call to `get_controller_info()` against Omada Software Controller 6.2.10.15
- local Home Assistant custom integration test exposing:
  - Omada Controller Device Status
  - Omada Controller Version
  - Omada Controller API Version

Home Assistant behavior validated locally:
- connected: `/api/info` responds with `configured=true`
- unavailable: Omada Controller service stopped / `/api/info` unreachable
- disconnected: simulated controller not operational state