### PR TITLE
Add VPN policy enable/disable support

### DIFF
--- a/src/tplink_omada_client/__init__.py
+++ b/src/tplink_omada_client/__init__.py
@@ -16,7 +16,7 @@ from .definitions import (
     OmadaHardwareUpgradeStatus,
     OmadaHardwareUpdateInfo,
 )
-from .vpn import OmadaVpnCategory, OmadaVpnPolicy
+from .vpn import OmadaVpnCategory, OmadaVpnPolicy, OmadaVpnType
 
 from . import definitions
 from . import exceptions
@@ -38,6 +38,7 @@ __all__ = [
     "OmadaSwitchPortDetails",
     "OmadaVpnCategory",
     "OmadaVpnPolicy",
+    "OmadaVpnType",
     "definitions",
     "exceptions",
     "clients",

--- a/src/tplink_omada_client/__init__.py
+++ b/src/tplink_omada_client/__init__.py
@@ -16,6 +16,7 @@ from .definitions import (
     OmadaHardwareUpgradeStatus,
     OmadaHardwareUpdateInfo,
 )
+from .vpn import OmadaVpnCategory, OmadaVpnPolicy
 
 from . import definitions
 from . import exceptions
@@ -35,6 +36,8 @@ __all__ = [
     "PortProfileOverrides",
     "SwitchPortSettings",
     "OmadaSwitchPortDetails",
+    "OmadaVpnCategory",
+    "OmadaVpnPolicy",
     "definitions",
     "exceptions",
     "clients",

--- a/src/tplink_omada_client/cli/__init__.py
+++ b/src/tplink_omada_client/cli/__init__.py
@@ -30,6 +30,7 @@ from . import (
     command_target,
     command_targets,
     command_unblock_client,
+    command_vpn,
     command_wan,
     command_controller_info,
 )
@@ -69,6 +70,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     command_target.arg_parser(subparsers)
     command_targets.arg_parser(subparsers)
     command_unblock_client.arg_parser(subparsers)
+    command_vpn.arg_parser(subparsers)
     command_wan.arg_parser(subparsers)
     command_controller_info.arg_parser(subparsers)
 

--- a/src/tplink_omada_client/cli/command_vpn.py
+++ b/src/tplink_omada_client/cli/command_vpn.py
@@ -1,0 +1,67 @@
+"""Implementation for 'vpn' command"""
+
+from argparse import ArgumentError, ArgumentParser
+
+from tplink_omada_client.vpn import OmadaVpnPolicy
+
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_checkbox_char, get_target_argument
+
+
+def _find_policy(policies: list[OmadaVpnPolicy], policy_ref: str) -> OmadaVpnPolicy:
+    matches = [
+        policy
+        for policy in policies
+        if policy_ref in (policy.policy_id, policy.unique_id, policy.name)
+    ]
+    if not matches:
+        raise ArgumentError(None, f"VPN policy '{policy_ref}' not found")
+    if len(matches) > 1:
+        matches_display = ", ".join(policy.unique_id for policy in matches)
+        raise ArgumentError(None, f"VPN policy name '{policy_ref}' is ambiguous: {matches_display}")
+    return matches[0]
+
+
+def _print_policy(policy: OmadaVpnPolicy) -> None:
+    print(f"{policy.policy_id:32} {policy.category.value:12} {get_checkbox_char(policy.enabled)} {policy.vpn_type_name:10} {policy.name}")
+
+
+async def command_vpn(args) -> int:
+    """Executes 'vpn' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        policies = await site_client.get_vpn_policies()
+
+        policy_ref = args["policy"]
+        if policy_ref:
+            policy = _find_policy(policies, policy_ref)
+            if args["enable"] or args["disable"]:
+                enabled = bool(args["enable"])
+                await site_client.set_vpn_policy_enabled(policy.policy_id, enabled)
+                print(f"VPN policy '{policy.name}' is now {'enabled' if enabled else 'disabled'}")
+                policies = await site_client.get_vpn_policies()
+                policy = _find_policy(policies, policy.policy_id)
+
+            _print_policy(policy)
+            dump_raw_data(args, policy)
+        else:
+            for policy in policies:
+                _print_policy(policy)
+                dump_raw_data(args, policy)
+
+    return 0
+
+
+def arg_parser(subparsers) -> None:
+    """Configures arguments parser for 'vpn' command"""
+    parser: ArgumentParser = subparsers.add_parser("vpn", help="Lists and controls VPN policies")
+    parser.set_defaults(func=command_vpn)
+
+    parser.add_argument("policy", nargs="?", help="The VPN policy ID, unique ID or name")
+    enabled_group = parser.add_mutually_exclusive_group()
+    enabled_group.add_argument("--enable", help="Enable the VPN policy", action="store_true")
+    enabled_group.add_argument("--disable", help="Disable the VPN policy", action="store_true")
+    parser.add_argument("-d", "--dump", help="Output raw VPN policy information", action="store_true")

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -39,8 +39,10 @@ from .devices import (
 )
 from .exceptions import (
     InvalidDevice,
+    OmadaClientException,
 )
 from .omadaapiconnection import OmadaApiConnection
+from .vpn import VPN_LIST_ENDPOINTS, OmadaVpnCategory, OmadaVpnPolicy
 
 
 @dataclass
@@ -736,3 +738,30 @@ class OmadaSiteClient:
         )
 
         return True
+
+    async def get_vpn_policies(self) -> list[OmadaVpnPolicy]:
+        """Get all VPN policies (server / client / site-to-site) for the site."""
+        policies: list[OmadaVpnPolicy] = []
+        for category in OmadaVpnCategory:
+            slug = VPN_LIST_ENDPOINTS.get(category.value, "")
+            if not slug:
+                continue
+            url = self._api.format_openapi_url(
+                f"vpn/{slug}", version="v2", site=self._site_id
+            )
+            try:
+                result = await self._api.request(
+                    "get", url, params={"page": 1, "pageSize": 100}
+                )
+            except OmadaClientException:
+                continue
+            for item in result.get("data", []):
+                policies.append(OmadaVpnPolicy(category, item))
+        return policies
+
+    async def set_vpn_policy_enabled(self, policy_id: str, enabled: bool) -> None:
+        """Enable or disable a VPN policy by id. Works for every VPN type."""
+        url = self._api.format_openapi_url(
+            f"vpn/{policy_id}/status", version="v1", site=self._site_id
+        )
+        await self._api.request("patch", url, json={"status": enabled})

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -42,7 +42,7 @@ from .exceptions import (
     OmadaClientException,
 )
 from .omadaapiconnection import OmadaApiConnection
-from .vpn import VPN_LIST_ENDPOINTS, OmadaVpnCategory, OmadaVpnPolicy
+from .vpn import _VPN_LIST_ENDPOINTS, OmadaVpnCategory, OmadaVpnPolicy
 
 
 @dataclass
@@ -743,9 +743,7 @@ class OmadaSiteClient:
         """Get all VPN policies (server / client / site-to-site) for the site."""
         policies: list[OmadaVpnPolicy] = []
         for category in OmadaVpnCategory:
-            slug = VPN_LIST_ENDPOINTS.get(category.value, "")
-            if not slug:
-                continue
+            slug = _VPN_LIST_ENDPOINTS[category]
             url = self._api.format_openapi_url(
                 f"vpn/{slug}", version="v2", site=self._site_id
             )

--- a/src/tplink_omada_client/vpn.py
+++ b/src/tplink_omada_client/vpn.py
@@ -8,15 +8,19 @@ from .definitions import OmadaApiData
 # OpenAPI list endpoints per VPN tab (relative to .../sites/{site}/vpn/).
 # All three confirmed from captures on controller 6.2.10.18.
 VPN_LIST_ENDPOINTS: dict[str, str] = {
-    "server": "client-to-site-vpn-servers",  # confirmed
-    "client": "client-to-site-vpn-clients",  # confirmed
-    "site_to_site": "site-to-site-vpns",     # confirmed
+    "server": "client-to-site-vpn-servers",
+    "client": "client-to-site-vpn-clients",
+    "site_to_site": "site-to-site-vpns",
 }
 
-# vpnType values seen so far: 2 = IPsec, 3 = OpenVPN.
 VPN_TYPE_NAMES: dict[int, str] = {
+    0: "L2TP",
+    1: "PPTP",
     2: "IPsec",
     3: "OpenVPN",
+    4: "Wireguard",
+    5: "SSL"
+
 }
 
 

--- a/src/tplink_omada_client/vpn.py
+++ b/src/tplink_omada_client/vpn.py
@@ -1,0 +1,71 @@
+"""VPN policy models for the Omada SDN controller (OpenAPI)."""
+
+from enum import StrEnum
+from typing import Any
+
+from .definitions import OmadaApiData
+
+# OpenAPI list endpoints per VPN tab (relative to .../sites/{site}/vpn/).
+# All three confirmed from captures on controller 6.2.10.18.
+VPN_LIST_ENDPOINTS: dict[str, str] = {
+    "server": "client-to-site-vpn-servers",  # confirmed
+    "client": "client-to-site-vpn-clients",  # confirmed (e.g. "NetflixVPN")
+    "site_to_site": "site-to-site-vpns",     # confirmed
+}
+
+# vpnType values seen so far: 2 = IPsec, 3 = OpenVPN.
+VPN_TYPE_NAMES: dict[int, str] = {
+    2: "IPsec",
+    3: "OpenVPN",
+}
+
+
+class OmadaVpnCategory(StrEnum):
+    """Which VPN tab a policy belongs to."""
+
+    SERVER = "server"
+    CLIENT = "client"
+    SITE_TO_SITE = "site_to_site"
+
+
+class OmadaVpnPolicy(OmadaApiData):
+    """A single VPN entry that can be enabled/disabled via .../vpn/{id}/status."""
+
+    def __init__(self, category: OmadaVpnCategory, data: dict[str, Any]) -> None:
+        super().__init__(data)
+        self._category = category
+
+    @property
+    def category(self) -> OmadaVpnCategory:
+        """The VPN tab this policy belongs to."""
+        return self._category
+
+    @property
+    def policy_id(self) -> str:
+        """Controller-side id, used as {id} in the status PATCH."""
+        return self._data["id"]
+
+    @property
+    def name(self) -> str:
+        """User-defined policy name."""
+        return self._data.get("name", self.policy_id)
+
+    @property
+    def enabled(self) -> bool:
+        """Current enabled state (the 'status' flag)."""
+        return bool(self._data.get("status", False))
+
+    @property
+    def vpn_type(self) -> int:
+        """Raw vpnType code (2 = IPsec, 3 = OpenVPN)."""
+        return int(self._data.get("vpnType", -1))
+
+    @property
+    def vpn_type_name(self) -> str:
+        """Human-readable protocol, falling back to the raw code."""
+        return VPN_TYPE_NAMES.get(self.vpn_type, f"VPN ({self.vpn_type})")
+
+    @property
+    def unique_id(self) -> str:
+        """Stable key: category + id."""
+        return f"{self._category}_{self.policy_id}"

--- a/src/tplink_omada_client/vpn.py
+++ b/src/tplink_omada_client/vpn.py
@@ -1,27 +1,9 @@
 """VPN policy models for the Omada SDN controller (OpenAPI)."""
 
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import Any
 
 from .definitions import OmadaApiData
-
-# OpenAPI list endpoints per VPN tab (relative to .../sites/{site}/vpn/).
-# All three confirmed from captures on controller 6.2.10.18.
-VPN_LIST_ENDPOINTS: dict[str, str] = {
-    "server": "client-to-site-vpn-servers",
-    "client": "client-to-site-vpn-clients",
-    "site_to_site": "site-to-site-vpns",
-}
-
-VPN_TYPE_NAMES: dict[int, str] = {
-    0: "L2TP",
-    1: "PPTP",
-    2: "IPsec",
-    3: "OpenVPN",
-    4: "Wireguard",
-    5: "SSL"
-
-}
 
 
 class OmadaVpnCategory(StrEnum):
@@ -30,6 +12,31 @@ class OmadaVpnCategory(StrEnum):
     SERVER = "server"
     CLIENT = "client"
     SITE_TO_SITE = "site_to_site"
+
+
+# OpenAPI list endpoints per VPN tab (relative to .../sites/{site}/vpn/).
+# All three confirmed from captures on controller 6.2.10.18.
+_VPN_LIST_ENDPOINTS: dict[OmadaVpnCategory, str] = {
+    OmadaVpnCategory.SERVER: "client-to-site-vpn-servers",
+    OmadaVpnCategory.CLIENT: "client-to-site-vpn-clients",
+    OmadaVpnCategory.SITE_TO_SITE: "site-to-site-vpns",
+}
+
+
+class OmadaVpnType(IntEnum):
+    """Known VPN protocol types."""
+
+    UNKNOWN = -1
+    L2TP = 0
+    PPTP = 1
+    IPSEC = 2
+    OPENVPN = 3
+    WIREGUARD = 4
+    SSL = 5
+
+    @classmethod
+    def _missing_(cls, _):
+        return OmadaVpnType.UNKNOWN
 
 
 class OmadaVpnPolicy(OmadaApiData):
@@ -60,14 +67,21 @@ class OmadaVpnPolicy(OmadaApiData):
         return bool(self._data.get("status", False))
 
     @property
-    def vpn_type(self) -> int:
-        """Raw vpnType code (2 = IPsec, 3 = OpenVPN)."""
-        return int(self._data.get("vpnType", -1))
+    def vpn_type(self) -> OmadaVpnType:
+        """VPN protocol type."""
+        try:
+            return OmadaVpnType(int(self._data.get("vpnType", -1)))
+        except (TypeError, ValueError):
+            return OmadaVpnType.UNKNOWN
 
     @property
     def vpn_type_name(self) -> str:
         """Human-readable protocol, falling back to the raw code."""
-        return VPN_TYPE_NAMES.get(self.vpn_type, f"VPN ({self.vpn_type})")
+        return {
+            OmadaVpnType.IPSEC: "IPsec",
+            OmadaVpnType.OPENVPN: "OpenVPN",
+            OmadaVpnType.WIREGUARD: "WireGuard",
+        }.get(self.vpn_type, self.vpn_type.name)
 
     @property
     def unique_id(self) -> str:

--- a/src/tplink_omada_client/vpn.py
+++ b/src/tplink_omada_client/vpn.py
@@ -9,7 +9,7 @@ from .definitions import OmadaApiData
 # All three confirmed from captures on controller 6.2.10.18.
 VPN_LIST_ENDPOINTS: dict[str, str] = {
     "server": "client-to-site-vpn-servers",  # confirmed
-    "client": "client-to-site-vpn-clients",  # confirmed (e.g. "NetflixVPN")
+    "client": "client-to-site-vpn-clients",  # confirmed
     "site_to_site": "site-to-site-vpns",     # confirmed
 }
 

--- a/tests/test_cli_vpn.py
+++ b/tests/test_cli_vpn.py
@@ -1,0 +1,145 @@
+"""Tests for the VPN CLI command."""
+
+import argparse
+import asyncio
+
+import pytest
+
+import tplink_omada_client.cli as cli
+from tplink_omada_client.cli import command_vpn
+from tplink_omada_client.cli.config import ControllerConfig
+from tplink_omada_client.vpn import OmadaVpnCategory, OmadaVpnPolicy, OmadaVpnType
+
+
+def _policy(policy_id: str, name: str, status: bool = True) -> OmadaVpnPolicy:
+    return OmadaVpnPolicy(
+        OmadaVpnCategory.SERVER,
+        {
+            "id": policy_id,
+            "name": name,
+            "status": status,
+            "vpnType": 3,
+        },
+    )
+
+
+class FakeSiteClient:
+    def __init__(self, policies: list[OmadaVpnPolicy]) -> None:
+        self.policies = policies
+        self.enabled_calls: list[tuple[str, bool]] = []
+
+    async def get_vpn_policies(self) -> list[OmadaVpnPolicy]:
+        return self.policies
+
+    async def set_vpn_policy_enabled(self, policy_id: str, enabled: bool) -> None:
+        self.enabled_calls.append((policy_id, enabled))
+        for policy in self.policies:
+            if policy.policy_id == policy_id:
+                policy.raw_data["status"] = enabled
+
+
+class FakeConnection:
+    def __init__(self, site_client: FakeSiteClient) -> None:
+        self.site_client = site_client
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get_site_client(self, site: str) -> FakeSiteClient:
+        return self.site_client
+
+
+def _run_command(monkeypatch, site_client: FakeSiteClient, args: dict) -> int:
+    config = ControllerConfig("url", "user", "pass", "Default", True)
+    monkeypatch.setattr(command_vpn, "get_target_config", lambda target: config)
+    monkeypatch.setattr(command_vpn, "to_omada_connection", lambda target_config: FakeConnection(site_client))
+    command_args = {
+        "target": "",
+        "policy": None,
+        "enable": False,
+        "disable": False,
+        "dump": False,
+    }
+    command_args.update(args)
+    return asyncio.run(command_vpn.command_vpn(command_args))
+
+
+def test_main_registers_vpn_command(monkeypatch):
+    seen = {}
+
+    async def fake_command(args):
+        seen.update(args)
+        return 0
+
+    monkeypatch.setattr(cli.command_vpn, "command_vpn", fake_command)
+
+    assert cli.main(["vpn"]) == 0
+    assert seen["policy"] is None
+
+
+def test_vpn_command_lists_policies(monkeypatch, capsys):
+    site_client = FakeSiteClient([_policy("policy-1", "Road warrior"), _policy("policy-2", "Site link", False)])
+
+    assert _run_command(monkeypatch, site_client, {}) == 0
+
+    output = capsys.readouterr().out
+    assert "policy-1" in output
+    assert "Road warrior" in output
+    assert "\u2611" in output
+    assert "policy-2" in output
+    assert "Site link" in output
+    assert "\u2610" in output
+
+
+def test_vpn_command_enables_policy_by_name(monkeypatch, capsys):
+    site_client = FakeSiteClient([_policy("policy-1", "Road warrior", False)])
+
+    assert _run_command(monkeypatch, site_client, {"policy": "Road warrior", "enable": True}) == 0
+
+    assert site_client.enabled_calls == [("policy-1", True)]
+    output = capsys.readouterr().out
+    assert "is now enabled" in output
+    assert "\u2611" in output
+
+
+def test_vpn_command_disables_policy_by_unique_id(monkeypatch):
+    site_client = FakeSiteClient([_policy("policy-1", "Road warrior", True)])
+
+    assert _run_command(monkeypatch, site_client, {"policy": "server_policy-1", "disable": True}) == 0
+
+    assert site_client.enabled_calls == [("policy-1", False)]
+
+
+def test_vpn_command_rejects_ambiguous_policy_name(monkeypatch):
+    site_client = FakeSiteClient([_policy("policy-1", "Office"), _policy("policy-2", "Office")])
+
+    with pytest.raises(argparse.ArgumentError, match="ambiguous"):
+        _run_command(monkeypatch, site_client, {"policy": "Office", "disable": True})
+
+    assert site_client.enabled_calls == []
+
+
+def test_vpn_command_rejects_unknown_policy(monkeypatch):
+    site_client = FakeSiteClient([_policy("policy-1", "Office")])
+
+    with pytest.raises(argparse.ArgumentError, match="not found"):
+        _run_command(monkeypatch, site_client, {"policy": "Missing", "enable": True})
+
+    assert site_client.enabled_calls == []
+
+
+def test_vpn_policy_uses_vpn_type_enum():
+    policy = _policy("policy-1", "Office")
+
+    assert policy.vpn_type == OmadaVpnType.OPENVPN
+    assert policy.vpn_type_name == "OpenVPN"
+
+
+def test_vpn_policy_handles_invalid_vpn_type():
+    policy = OmadaVpnPolicy(OmadaVpnCategory.SERVER, {"id": "policy-1", "vpnType": None})
+
+    assert policy.vpn_type == OmadaVpnType.UNKNOWN
+    assert policy.vpn_type_name == "UNKNOWN"


### PR DESCRIPTION
## Summary

Adds support for listing and toggling VPN policies on Omada gateways, covering all three VPN categories:

- **Client-to-Site VPN Servers** (`vpn/client-to-site-vpn-servers`)
- **VPN Clients** (`vpn/client-to-site-vpn-clients`)
- **Site-to-Site VPN** (`vpn/site-to-site-vpns`)

New API on `OmadaSiteClient`:

- `get_vpn_policies() -> list[OmadaVpnPolicy]` — lists all VPN policies across the three categories
- `set_vpn_policy_enabled(policy_id, enabled)` — enables/disables a policy via `PATCH openapi/v1/{cid}/sites/{site}/vpn/{id}/status`

New module `vpn.py` with `OmadaVpnPolicy` (extends `OmadaApiData`, consistent with the other API wrappers) and `OmadaVpnCategory`.

## Notes for review

- **Endpoint source:** The endpoints are not part of the published OpenAPI documentation; they were captured from the controller web UI's network traffic (controller 6.2.10.18, ER707-M2 gateway). List endpoints are `GET` on OpenAPI v2, the status toggle is `PATCH` on OpenAPI v1 — matching what the web UI itself uses.
- **Graceful degradation:** `get_vpn_policies()` catches `OmadaClientException` per category and skips it, so firmware that lacks one of the VPN tabs doesn't break the whole call.
- **`vpnType` mapping:** Only codes seen in captures are mapped so far (0 = L2TP, 1 = PPTP, 2 = IPsec, 3 = OpenVPN, 4 = Wireguard, 5 = SSL). Unknown codes fall back to `"VPN (<code>)"`.

## Testing

Verified live against controller 6.2.10.18 / ER707-M2:

- All three categories list correctly (2 OpenVPN servers, 1 OpenVPN client, 1 IPsec site-to-site)
- Status toggle works for every category and is reflected in the controller UI
- Existing test suite passes; no new lint findings