### PR TITLE
Fix switch port overrides for ports with no override already

### DIFF
--- a/src/tplink_omada_client/cli/__init__.py
+++ b/src/tplink_omada_client/cli/__init__.py
@@ -20,6 +20,7 @@ from . import (
     command_gateway,
     command_known_clients,
     command_poe,
+    command_port_profiles,
     command_reboot,
     command_reconnect_client,
     command_set_client_name,
@@ -59,6 +60,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     command_gateway.arg_parser(subparsers)
     command_known_clients.arg_parser(subparsers)
     command_poe.arg_parser(subparsers)
+    command_port_profiles.arg_parser(subparsers)
     command_reboot.arg_parser(subparsers)
     command_reconnect_client.arg_parser(subparsers)
     command_certificate.arg_parser(subparsers)

--- a/src/tplink_omada_client/cli/command_port_profiles.py
+++ b/src/tplink_omada_client/cli/command_port_profiles.py
@@ -1,0 +1,75 @@
+"""Implementation for 'port_profiles' command"""
+
+from argparse import ArgumentError, ArgumentParser
+
+from tplink_omada_client.devices import OmadaPortProfile
+
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_checkbox_char, get_target_argument
+
+
+def _find_profile(profiles: list[OmadaPortProfile], profile_ref: str) -> OmadaPortProfile:
+    matches = [profile for profile in profiles if profile_ref in (profile.profile_id, profile.name)]
+    if not matches:
+        raise ArgumentError(None, f"Port profile '{profile_ref}' not found")
+    if len(matches) > 1:
+        matches_display = ", ".join(profile.profile_id for profile in matches)
+        raise ArgumentError(None, f"Port profile name '{profile_ref}' is ambiguous: {matches_display}")
+    return matches[0]
+
+
+def _print_profile_row(profile: OmadaPortProfile) -> None:
+    profile_type = profile.raw_data.get("type", "")
+    print(
+        f"{profile.profile_id:32} {profile_type!s:4} {profile.poe_mode.name:19} "
+        f"{profile.eth_802_1x_control.name:18} {profile.name}"
+    )
+
+
+def _print_profile_details(profile: OmadaPortProfile) -> None:
+    print(f"Port Profile: {profile.name}")
+    print(f"    ID:                    {profile.profile_id}")
+    print(f"    Type:                  {profile.raw_data.get('type', '')}")
+    print(f"    PoE:                   {profile.poe_mode.name}")
+    print(f"    802.1X:                {profile.eth_802_1x_control.name}")
+    print(f"    LLDP-MED:              {get_checkbox_char(profile.lldp_med_enabled)}")
+    print(f"    Spanning Tree:         {get_checkbox_char(profile.spanning_tree_enabled)}")
+    print(f"    Loopback Detect:       {get_checkbox_char(profile.loopback_detect_enabled)}")
+    print(f"    Port Isolation:        {get_checkbox_char(profile.port_isolation_enabled)}")
+    if profile.has_eee:
+        print(f"    EEE:                   {get_checkbox_char(profile.eee_enabled)}")
+    if profile.has_flow_control:
+        print(f"    Flow Control:          {get_checkbox_char(profile.flow_control_enabled)}")
+    if profile.has_loopback_detect_vlan_based:
+        print(f"    VLAN Loopback Detect:  {get_checkbox_char(profile.loopback_detect_vlan_based_enabled)}")
+
+
+async def command_port_profiles(args) -> int:
+    """Executes 'port_profiles' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        profiles = await site_client.get_port_profiles()
+
+        profile_ref = args["profile"]
+        if profile_ref:
+            profile = _find_profile(profiles, profile_ref)
+            _print_profile_details(profile)
+            dump_raw_data(args, profile)
+        else:
+            for profile in profiles:
+                _print_profile_row(profile)
+                dump_raw_data(args, profile)
+
+    return 0
+
+
+def arg_parser(subparsers) -> None:
+    """Configures arguments parser for 'port_profiles' command"""
+    parser: ArgumentParser = subparsers.add_parser("port_profiles", help="Lists switch port profiles")
+    parser.set_defaults(func=command_port_profiles)
+
+    parser.add_argument("profile", nargs="?", help="The port profile ID or name")
+    parser.add_argument("-d", "--dump", help="Output raw port profile information", action="store_true")

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -516,7 +516,7 @@ class OmadaSwitchPortDetails(OmadaSwitchPort):
     @property
     def eth_802_1x_control(self) -> Eth802Dot1X:
         """802.1x Auth mode"""
-        return Eth802Dot1X(self._data["dot1x"])
+        return Eth802Dot1X(self._data.get("dot1x", Eth802Dot1X.UNKNOWN))
 
     @property
     def lldp_med_enabled(self) -> bool:
@@ -625,7 +625,7 @@ class OmadaPortProfile(OmadaApiData):
     @property
     def site(self) -> str:
         """Site which this profile is valid for."""
-        return self._data["site"]
+        return self._data.get("site", "")
 
     @property
     def name(self) -> str:
@@ -645,7 +645,7 @@ class OmadaPortProfile(OmadaApiData):
     @property
     def eth_802_1x_control(self) -> Eth802Dot1X:
         """802.1x Auth mode"""
-        return Eth802Dot1X(self._data["dot1x"])
+        return Eth802Dot1X(self._data.get("dot1x", Eth802Dot1X.UNKNOWN))
 
     @property
     def lldp_med_enabled(self) -> bool:

--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -198,6 +198,30 @@ class OmadaApiConnection:
             for item in data:
                 yield item
 
+    async def iterate_pages_openapi_get(self, url: str, params: dict[str, Any] | None = None) -> AsyncIterable[dict[str, Any]]:
+        """Iterates all the entries of a paged endpoint using GET with query parameters (OpenAPI v2)"""
+        request_params = {}
+        if params is not None:
+            request_params.update(params)
+        actual_page_size = _PAGE_SIZE
+
+        current_page = 1
+        has_next = True
+        while has_next:
+            request_params["pageSize"] = actual_page_size
+            request_params["page"] = current_page
+            response = await self.request("get", url, params=request_params)
+
+            # Setup next page request
+            actual_page_size = int(response["currentSize"])
+            total_rows = int(response["totalRows"])
+            has_next = total_rows > current_page * actual_page_size
+            current_page += 1
+
+            data: list[dict[str, Any]] = response["data"]
+            for item in data:
+                yield item
+
     async def request(self, method: str, url: str, params=None, json=None, data: Payload | None = None) -> Any:
         """Perform a request specific to the controlller, with authentication"""
 

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -487,7 +487,9 @@ class OmadaSiteClient:
 
         enable_poe = new_overrides.enable_poe if new_overrides.enable_poe is not None else existing_overrides.enable_poe
         payload["poe"] = PoEMode.ENABLED if enable_poe else PoEMode.DISABLED
-        payload["dot1x"] = new_overrides.dot1x_mode if new_overrides.dot1x_mode is not None else existing_overrides.dot1x_mode
+        dot1x = new_overrides.dot1x_mode if new_overrides.dot1x_mode is not None else existing_overrides.dot1x_mode
+        if dot1x is not None and dot1x != Eth802Dot1X.UNKNOWN:
+            payload["dot1x"] = dot1x
         payload["lldpMedEnable"] = (
             new_overrides.lldp_med_enable if new_overrides.lldp_med_enable is not None else existing_overrides.lldp_med_enable
         )
@@ -575,6 +577,10 @@ class OmadaSiteClient:
 
     async def get_port_profiles(self) -> list[OmadaPortProfile]:
         """Lists the available switch port profiles that can be applied."""
+
+        if (await self._api.get_controller_version()) >= AwesomeVersion("6.2.0.0"):
+            request_url = self._api.format_openapi_url("lan-profiles", version="v2", site=self._site_id)
+            return [OmadaPortProfile(p) async for p in self._api.iterate_pages_openapi_get(request_url)]
 
         result = await self._api.request("get", self._api.format_url("setting/lan/profileSummary", self._site_id))
 
@@ -744,13 +750,9 @@ class OmadaSiteClient:
         policies: list[OmadaVpnPolicy] = []
         for category in OmadaVpnCategory:
             slug = _VPN_LIST_ENDPOINTS[category]
-            url = self._api.format_openapi_url(
-                f"vpn/{slug}", version="v2", site=self._site_id
-            )
+            url = self._api.format_openapi_url(f"vpn/{slug}", version="v2", site=self._site_id)
             try:
-                result = await self._api.request(
-                    "get", url, params={"page": 1, "pageSize": 100}
-                )
+                result = await self._api.request("get", url, params={"page": 1, "pageSize": 100})
             except OmadaClientException:
                 continue
             for item in result.get("data", []):
@@ -759,7 +761,5 @@ class OmadaSiteClient:
 
     async def set_vpn_policy_enabled(self, policy_id: str, enabled: bool) -> None:
         """Enable or disable a VPN policy by id. Works for every VPN type."""
-        url = self._api.format_openapi_url(
-            f"vpn/{policy_id}/status", version="v1", site=self._site_id
-        )
+        url = self._api.format_openapi_url(f"vpn/{policy_id}/status", version="v1", site=self._site_id)
         await self._api.request("patch", url, json={"status": enabled})

--- a/tests/test_cli_port_profiles.py
+++ b/tests/test_cli_port_profiles.py
@@ -1,0 +1,119 @@
+"""Tests for the port_profiles CLI command."""
+
+import argparse
+import asyncio
+
+import pytest
+
+import tplink_omada_client.cli as cli
+from tplink_omada_client.cli import command_port_profiles
+from tplink_omada_client.cli.config import ControllerConfig
+from tplink_omada_client.devices import OmadaPortProfile
+
+
+def _profile(profile_id: str, name: str, dot1x: int = 2) -> OmadaPortProfile:
+    return OmadaPortProfile(
+        {
+            "id": profile_id,
+            "name": name,
+            "type": 2,
+            "poe": 2,
+            "dot1x": dot1x,
+            "portIsolationEnable": False,
+            "lldpMedEnable": True,
+            "bandWidthCtrlType": 0,
+            "spanningTreeEnable": False,
+            "loopbackDetectEnable": True,
+            "eeeEnable": False,
+            "flowControlEnable": False,
+            "loopbackDetectVlanBasedEnable": False,
+        }
+    )
+
+
+class FakeSiteClient:
+    def __init__(self, profiles: list[OmadaPortProfile]) -> None:
+        self.profiles = profiles
+
+    async def get_port_profiles(self) -> list[OmadaPortProfile]:
+        return self.profiles
+
+
+class FakeConnection:
+    def __init__(self, site_client: FakeSiteClient) -> None:
+        self.site_client = site_client
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get_site_client(self, site: str) -> FakeSiteClient:
+        return self.site_client
+
+
+def _run_command(monkeypatch, site_client: FakeSiteClient, args: dict) -> int:
+    config = ControllerConfig("url", "user", "pass", "Default", True)
+    monkeypatch.setattr(command_port_profiles, "get_target_config", lambda target: config)
+    monkeypatch.setattr(command_port_profiles, "to_omada_connection", lambda target_config: FakeConnection(site_client))
+    command_args = {
+        "target": "",
+        "profile": None,
+        "dump": False,
+    }
+    command_args.update(args)
+    return asyncio.run(command_port_profiles.command_port_profiles(command_args))
+
+
+def test_main_registers_port_profiles_command(monkeypatch):
+    seen = {}
+
+    async def fake_command(args):
+        seen.update(args)
+        return 0
+
+    monkeypatch.setattr(cli.command_port_profiles, "command_port_profiles", fake_command)
+
+    assert cli.main(["port_profiles"]) == 0
+    assert seen["profile"] is None
+
+
+def test_port_profiles_command_lists_profiles(monkeypatch, capsys):
+    site_client = FakeSiteClient([_profile("profile-1", "Default"), _profile("profile-2", "Camera")])
+
+    assert _run_command(monkeypatch, site_client, {}) == 0
+
+    output = capsys.readouterr().out
+    assert "profile-1" in output
+    assert "Default" in output
+    assert "USE_DEVICE_SETTINGS" in output
+    assert "profile-2" in output
+    assert "Camera" in output
+
+
+def test_port_profiles_command_views_profile_by_name(monkeypatch, capsys):
+    site_client = FakeSiteClient([_profile("profile-1", "Default")])
+
+    assert _run_command(monkeypatch, site_client, {"profile": "Default"}) == 0
+
+    output = capsys.readouterr().out
+    assert "Port Profile: Default" in output
+    assert "profile-1" in output
+    assert "802.1X" in output
+    assert "AUTO" in output
+    assert "LLDP-MED" in output
+
+
+def test_port_profiles_command_rejects_ambiguous_profile_name(monkeypatch):
+    site_client = FakeSiteClient([_profile("profile-1", "Default"), _profile("profile-2", "Default")])
+
+    with pytest.raises(argparse.ArgumentError, match="ambiguous"):
+        _run_command(monkeypatch, site_client, {"profile": "Default"})
+
+
+def test_port_profiles_command_rejects_unknown_profile(monkeypatch):
+    site_client = FakeSiteClient([_profile("profile-1", "Default")])
+
+    with pytest.raises(argparse.ArgumentError, match="not found"):
+        _run_command(monkeypatch, site_client, {"profile": "Missing"})

--- a/tests/test_switch_port_profiles.py
+++ b/tests/test_switch_port_profiles.py
@@ -1,0 +1,207 @@
+"""Tests for switch port profile handling."""
+
+import asyncio
+
+from awesomeversion import AwesomeVersion
+
+from tplink_omada_client.definitions import Eth802Dot1X, LinkDuplex, LinkSpeed, PoEMode
+from tplink_omada_client.devices import OmadaPortProfile, OmadaSwitchPortDetails
+from tplink_omada_client.omadaapiconnection import OmadaApiConnection
+from tplink_omada_client.omadasiteclient import OmadaSiteClient, PortProfileOverrides, SwitchPortSettings
+
+
+def _port_data(profile_override: bool = False) -> dict:
+    return {
+        "id": "port-id",
+        "port": 1,
+        "name": "Port 1",
+        "profileId": "profile-1",
+        "profileName": "Default",
+        "profileOverrideEnable": profile_override,
+        "supportPoe": True,
+        "poe": PoEMode.ENABLED,
+        "maxSpeed": LinkSpeed.SPEED_1_GBPS,
+        "linkSpeed": LinkSpeed.SPEED_AUTO,
+        "duplex": LinkDuplex.AUTO,
+        "type": 0,
+        "operation": "switching",
+        "disable": False,
+        "portStatus": {"linkStatus": 0, "poe": False},
+        "bandWidthCtrlType": 0,
+        "tagIds": [],
+    }
+
+
+def _profile_data(dot1x=Eth802Dot1X.AUTO) -> dict:
+    result = {
+        "id": "profile-1",
+        "name": "Default",
+        "poe": PoEMode.ENABLED,
+        "portIsolationEnable": False,
+        "lldpMedEnable": True,
+        "bandWidthCtrlType": 0,
+        "spanningTreeEnable": False,
+        "loopbackDetectEnable": True,
+        "eeeEnable": False,
+        "flowControlEnable": False,
+        "loopbackDetectVlanBasedEnable": False,
+        "dhcpL2RelaySettings": {"enable": False},
+        "type": 2,
+    }
+    if dot1x is not None:
+        result["dot1x"] = dot1x
+    return result
+
+
+class FakeApi:
+    def __init__(self, version: str = "6.2.0.0", profiles: list[dict] | None = None) -> None:
+        self.version = AwesomeVersion(version)
+        self.profiles = profiles or [_profile_data()]
+        self.requests = []
+        self.openapi_urls = []
+        self.legacy_urls = []
+
+    async def get_controller_version(self) -> AwesomeVersion:
+        return self.version
+
+    def format_openapi_url(self, end_point: str, version: str = "v1", site: str | None = None) -> str:
+        url = f"openapi/{version}/{site}/{end_point}"
+        self.openapi_urls.append(url)
+        return url
+
+    def format_url(self, end_point: str, site: str | None = None) -> str:
+        url = f"api/{site}/{end_point}"
+        self.legacy_urls.append(url)
+        return url
+
+    async def iterate_pages_openapi_get(self, url: str, params: dict | None = None):
+        self.requests.append(("iterate_pages_openapi_get", url, params))
+        for profile in self.profiles:
+            yield profile
+
+    async def request(self, method: str, url: str, params=None, json=None, data=None):
+        self.requests.append((method, url, params, json, data))
+        if method == "get" and url.endswith("profileSummary"):
+            return {"data": self.profiles}
+        if method == "get" and url.endswith("/ports/1"):
+            return _port_data()
+        if method == "patch":
+            return {}
+        raise AssertionError(f"Unexpected request: {method} {url}")
+
+
+class FakePagedApi:
+    def __init__(self) -> None:
+        self.requests = []
+
+    async def request(self, method: str, url: str, params=None):
+        self.requests.append((method, url, params.copy()))
+        page = params["page"]
+        return {
+            "totalRows": 2,
+            "currentSize": 1,
+            "data": [{"id": f"profile-{page}"}],
+        }
+
+
+def test_port_profile_dot1x_defaults_to_unknown_when_missing():
+    profile = OmadaPortProfile(_profile_data(dot1x=None))
+    port = OmadaSwitchPortDetails(_port_data())
+
+    assert profile.eth_802_1x_control == Eth802Dot1X.UNKNOWN
+    assert port.eth_802_1x_control == Eth802Dot1X.UNKNOWN
+
+
+def test_openapi_get_paginator_uses_page_and_page_size_params():
+    api = FakePagedApi()
+
+    profiles = asyncio.run(_collect_openapi_get_pages(api))
+
+    assert profiles == [{"id": "profile-1"}, {"id": "profile-2"}]
+    assert api.requests == [
+        ("get", "openapi/v2/site-id/lan-profiles", {"pageSize": 100, "page": 1}),
+        ("get", "openapi/v2/site-id/lan-profiles", {"pageSize": 1, "page": 2}),
+    ]
+
+
+async def _collect_openapi_get_pages(api: FakePagedApi) -> list[dict]:
+    return [
+        item
+        async for item in OmadaApiConnection.iterate_pages_openapi_get(
+            api,
+            "openapi/v2/site-id/lan-profiles",
+        )
+    ]
+
+
+def test_get_port_profiles_uses_openapi_lan_profiles_for_modern_controllers():
+    api = FakeApi(profiles=[_profile_data()])
+    client = OmadaSiteClient("site-id", api)
+
+    profiles = asyncio.run(client.get_port_profiles())
+
+    assert len(profiles) == 1
+    assert profiles[0].profile_id == "profile-1"
+    assert profiles[0].eth_802_1x_control == Eth802Dot1X.AUTO
+    assert api.openapi_urls == ["openapi/v2/site-id/lan-profiles"]
+    assert api.requests == [("iterate_pages_openapi_get", "openapi/v2/site-id/lan-profiles", None)]
+
+
+def test_get_port_profiles_uses_legacy_profile_summary_before_6_2():
+    api = FakeApi(version="6.1.0", profiles=[_profile_data()])
+    client = OmadaSiteClient("site-id", api)
+
+    profiles = asyncio.run(client.get_port_profiles())
+
+    assert len(profiles) == 1
+    assert profiles[0].profile_id == "profile-1"
+    assert api.openapi_urls == []
+    assert api.requests == [
+        ("get", "api/site-id/setting/lan/profileSummary", None, None, None),
+    ]
+
+
+def test_update_switch_port_poe_override_preserves_profile_dot1x():
+    api = FakeApi(profiles=[_profile_data(dot1x=Eth802Dot1X.FORCE_AUTHORIZED)])
+    client = OmadaSiteClient("site-id", api)
+    port = OmadaSwitchPortDetails(_port_data())
+
+    asyncio.run(
+        client.update_switch_port(
+            "switch-mac",
+            port,
+            SwitchPortSettings(
+                profile_override_enabled=True,
+                profile_overrides=PortProfileOverrides(enable_poe=False),
+            ),
+        )
+    )
+
+    patch_requests = [request for request in api.requests if request[0] == "patch"]
+    assert len(patch_requests) == 1
+    payload = patch_requests[0][3]
+    assert payload["poe"] == PoEMode.DISABLED
+    assert payload["dot1x"] == Eth802Dot1X.FORCE_AUTHORIZED
+
+
+def test_update_switch_port_poe_override_omits_missing_dot1x():
+    api = FakeApi(profiles=[_profile_data(dot1x=None)])
+    client = OmadaSiteClient("site-id", api)
+    port = OmadaSwitchPortDetails(_port_data())
+
+    asyncio.run(
+        client.update_switch_port(
+            "switch-mac",
+            port,
+            SwitchPortSettings(
+                profile_override_enabled=True,
+                profile_overrides=PortProfileOverrides(enable_poe=False),
+            ),
+        )
+    )
+
+    patch_requests = [request for request in api.requests if request[0] == "patch"]
+    assert len(patch_requests) == 1
+    payload = patch_requests[0][3]
+    assert payload["poe"] == PoEMode.DISABLED
+    assert "dot1x" not in payload


### PR DESCRIPTION
When setting port profile overrides on a port that doesn't already have overrides, the port override structure is initialised from the port's current profile.
The Omada API changed in 6.2, so profile data is no longer included in the profile list. There is a new V2 OpenAPI call that can be made to pull port profile information. Using this API allows us to populate the profile override structure correctly.
Added a new CLI to show port profile information.