### PR TITLE
Expose software controller update info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tplink_omada_client"
-version = "1.5.8"
+version = "1.5.9"
 authors = [
   { name="Mark Godwin", email="10632972+MarkGodwin@users.noreply.github.com" },
 ]

--- a/src/tplink_omada_client/__init__.py
+++ b/src/tplink_omada_client/__init__.py
@@ -6,6 +6,7 @@ from .definitions import (
     OmadaControllerUpdateInfo,
     OmadaHardwareUpdateInfo,
     OmadaHardwareUpgradeStatus,
+    OmadaSoftwareUpdateInfo,
 )
 from .devices import OmadaSwitchPortDetails
 from .omadaclient import OmadaClient, OmadaSite
@@ -32,6 +33,7 @@ __all__ = [
     "OmadaHardwareUpgradeStatus",
     "OmadaSite",
     "OmadaSiteClient",
+    "OmadaSoftwareUpdateInfo",
     "OmadaSwitchPortDetails",
     "OmadaVpnCategory",
     "OmadaVpnPolicy",

--- a/src/tplink_omada_client/cli/command_firmware.py
+++ b/src/tplink_omada_client/cli/command_firmware.py
@@ -13,13 +13,24 @@ async def command_firmware(args) -> int:
 
     async with to_omada_connection(config) as client:
         controller_updates = await client.check_firmware_updates()
+        controller_update_found = False
+        if controller_updates.software:
+            software_update = controller_updates.software
+            status = "\u2757 UPDATE" if software_update.upgrade else "\u2713 UP-TO-DATE"
+            print(f"{'Controller Software':<30} {software_update.current_version:<36} {software_update.latest_version:<36} {status}")
+            if software_update.upgrade and software_update.release_notes and args["release_notes"]:
+                print(f"  Release Notes: {software_update.release_notes}")
+            controller_update_found = True
+
         if controller_updates.hardware:
             hardware_update = controller_updates.hardware
             status = "\u2757 UPDATE" if hardware_update.upgrade else "\u2713 UP-TO-DATE"
-            print(f"{'Controller':<30} {hardware_update.current_version:<36} {hardware_update.latest_version:<36} {status}")
+            print(f"{'Controller Firmware':<30} {hardware_update.current_version:<36} {hardware_update.latest_version:<36} {status}")
             if hardware_update.upgrade and hardware_update.release_notes and args["release_notes"]:
                 print(f"  Release Notes: {hardware_update.release_notes}")
-        else:
+            controller_update_found = True
+
+        if not controller_update_found:
             print("No controller firmware updates available.")
 
         dump_raw_data(args, controller_updates)

--- a/src/tplink_omada_client/definitions.py
+++ b/src/tplink_omada_client/definitions.py
@@ -357,6 +357,30 @@ class OmadaHardwareUpdateInfo(OmadaApiData):
         return self._data.get("fwReleaseLog", None)
 
 
+class OmadaSoftwareUpdateInfo(OmadaApiData):
+    """Information about available software controller updates."""
+
+    @property
+    def upgrade(self) -> bool:
+        """Whether a software upgrade is available."""
+        return self._data["upgrade"]
+
+    @property
+    def latest_version(self) -> str:
+        """The latest available software version."""
+        return self._data.get("latestVersion", self.current_version)
+
+    @property
+    def current_version(self) -> str:
+        """The currently installed software version."""
+        return self._data["currentVersion"]
+
+    @property
+    def release_notes(self) -> str | None:
+        """Release notes for the latest software version."""
+        return self._data.get("releaseLog", None)
+
+
 class OmadaControllerUpdateInfo(OmadaApiData):
     """Information about available controller and device firmware updates."""
 
@@ -364,6 +388,11 @@ class OmadaControllerUpdateInfo(OmadaApiData):
     def hardware(self) -> OmadaHardwareUpdateInfo | None:
         """Information about available hardware controller firmware updates."""
         return OmadaHardwareUpdateInfo(self._data["hardware"]) if "hardware" in self._data else None
+
+    @property
+    def software(self) -> OmadaSoftwareUpdateInfo | None:
+        """Information about available software controller updates."""
+        return OmadaSoftwareUpdateInfo(self._data["software"]) if "software" in self._data else None
 
 
 class OmadaHardwareUpgradeStatus(OmadaApiData):

--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -228,7 +228,12 @@ class OmadaApiConnection:
         if not await self._check_login():
             await self.login()
 
-        return await self._do_request(method, url, params=params, json=json, data=data)
+        try:
+            return await self._do_request(method, url, params=params, json=json, data=data)
+        except (LoginFailed, LoginSessionClosed):
+            self._csrf_token = None
+            await self.login()
+            return await self._do_request(method, url, params=params, json=json, data=data)
 
     async def get_controller_version(self) -> AwesomeVersion:
         """Get the controller version as an AwesomeVersion object."""

--- a/src/tplink_omada_client/omadaapiconnection.py
+++ b/src/tplink_omada_client/omadaapiconnection.py
@@ -90,6 +90,8 @@ class OmadaApiConnection:
         However, you may want to attempt a login to check connectivity.
         """
 
+        self._clear_login_state()
+
         version, controller_id = await self._get_controller_info()
 
         if AwesomeVersion(version) < AwesomeVersion("5.1.0"):
@@ -105,6 +107,12 @@ class OmadaApiConnection:
         self._last_logon = time.time()
 
         return self._controller_id
+
+    def _clear_login_state(self) -> None:
+        """Clear authentication state associated with this controller."""
+        self._csrf_token = None
+        if self._session is not None:
+            self._session.cookie_jar.clear_domain(self._host)
 
     async def _check_login(self) -> bool:
         if self._csrf_token is None:
@@ -231,7 +239,6 @@ class OmadaApiConnection:
         try:
             return await self._do_request(method, url, params=params, json=json, data=data)
         except (LoginFailed, LoginSessionClosed):
-            self._csrf_token = None
             await self.login()
             return await self._do_request(method, url, params=params, json=json, data=data)
 

--- a/src/tplink_omada_client/omadaclient.py
+++ b/src/tplink_omada_client/omadaclient.py
@@ -147,10 +147,7 @@ class OmadaClient:
         await self._api.request("patch", url, json=payload)
 
     async def check_firmware_updates(self) -> OmadaControllerUpdateInfo:
-        """Check if firmware updates are available for the Omada hardware controller
-
-        Software Controller updates are probably not available via this API
-        """
+        """Check if controller firmware or software updates are available."""
         result = await self._api.request("get", self._api.format_url("controller/notification/updateInfo"))
 
         return OmadaControllerUpdateInfo(result)

--- a/tests/test_controller_update_info.py
+++ b/tests/test_controller_update_info.py
@@ -1,0 +1,41 @@
+"""Tests for controller update notification data."""
+
+from tplink_omada_client.definitions import OmadaControllerUpdateInfo
+
+
+def test_controller_update_info_reads_hardware_update():
+    """Hardware controller firmware updates remain available."""
+    update_info = OmadaControllerUpdateInfo({
+        "hardware": {
+            "upgrade": True,
+            "currentVersion": "1.0.0",
+            "latestVersion": "1.0.1",
+            "fwReleaseLog": "Fixed things.",
+        }
+    })
+
+    assert update_info.software is None
+    assert update_info.hardware is not None
+    assert update_info.hardware.upgrade is True
+    assert update_info.hardware.current_version == "1.0.0"
+    assert update_info.hardware.latest_version == "1.0.1"
+    assert update_info.hardware.release_notes == "Fixed things."
+
+
+def test_controller_update_info_reads_software_update():
+    """Software controller updates are exposed when Omada returns them."""
+    update_info = OmadaControllerUpdateInfo({
+        "software": {
+            "upgrade": True,
+            "currentVersion": "6.2.10.17",
+            "latestVersion": "6.2.14.6 Build 20260617091728",
+            "releaseLog": "New controller software available.",
+        }
+    })
+
+    assert update_info.hardware is None
+    assert update_info.software is not None
+    assert update_info.software.upgrade is True
+    assert update_info.software.current_version == "6.2.10.17"
+    assert update_info.software.latest_version == "6.2.14.6 Build 20260617091728"
+    assert update_info.software.release_notes == "New controller software available."

--- a/tests/test_omadaapiconnection.py
+++ b/tests/test_omadaapiconnection.py
@@ -1,0 +1,74 @@
+"""Tests for the low-level Omada API connection."""
+
+import asyncio
+import time
+from typing import Any
+
+from tplink_omada_client.omadaapiconnection import OmadaApiConnection
+
+
+class FakeResponse:
+    """Minimal aiohttp response stand-in."""
+
+    def __init__(self, content_type: str, payload: dict[str, Any] | None = None) -> None:
+        self.status = 200
+        self.content_type = content_type
+        self._payload = payload or {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def json(self, encoding: str = "utf-8") -> dict[str, Any]:
+        return self._payload
+
+
+class FakeSession:
+    """Minimal aiohttp session stand-in."""
+
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self.responses = responses
+        self.requests: list[tuple[str, str, dict[str, str]]] = []
+
+    def request(self, method: str, url: str, **kwargs) -> FakeResponse:
+        self.requests.append((method, url, kwargs.get("headers", {})))
+        return self.responses.pop(0)
+
+
+def test_authenticated_request_relogs_after_closed_session():
+    """Authenticated requests retry once when Omada invalidates the session."""
+    session = FakeSession(
+        [
+            FakeResponse("text/html"),
+            FakeResponse(
+                "application/json",
+                {
+                    "errorCode": 0,
+                    "result": {
+                        "controllerVer": "6.2.10.17",
+                        "omadacId": "controller-id",
+                    },
+                },
+            ),
+            FakeResponse(
+                "application/json",
+                {"errorCode": 0, "result": {"token": "new-token"}},
+            ),
+            FakeResponse("application/json", {"errorCode": 0, "result": {"ok": True}}),
+        ]
+    )
+    connection = OmadaApiConnection(
+        "https://omada.example:8043", "user", "pass", session
+    )
+    connection._controller_id = "controller-id"
+    connection._csrf_token = "old-token"
+    connection._last_logon = time.time()
+
+    result = asyncio.run(connection.request("get", "https://omada.example/request"))
+
+    assert result == {"ok": True}
+    assert connection._csrf_token == "new-token"
+    assert session.requests[0][2]["Csrf-Token"] == "old-token"
+    assert session.requests[-1][2]["Csrf-Token"] == "new-token"

--- a/tests/test_omadaapiconnection.py
+++ b/tests/test_omadaapiconnection.py
@@ -31,10 +31,21 @@ class FakeSession:
     def __init__(self, responses: list[FakeResponse]) -> None:
         self.responses = responses
         self.requests: list[tuple[str, str, dict[str, str]]] = []
+        self.cookie_jar = FakeCookieJar()
 
     def request(self, method: str, url: str, **kwargs) -> FakeResponse:
         self.requests.append((method, url, kwargs.get("headers", {})))
         return self.responses.pop(0)
+
+
+class FakeCookieJar:
+    """Minimal aiohttp cookie jar stand-in."""
+
+    def __init__(self) -> None:
+        self.cleared_domains: list[str] = []
+
+    def clear_domain(self, domain: str) -> None:
+        self.cleared_domains.append(domain)
 
 
 def test_authenticated_request_relogs_after_closed_session():
@@ -72,3 +83,43 @@ def test_authenticated_request_relogs_after_closed_session():
     assert connection._csrf_token == "new-token"
     assert session.requests[0][2]["Csrf-Token"] == "old-token"
     assert session.requests[-1][2]["Csrf-Token"] == "new-token"
+    assert session.cookie_jar.cleared_domains == ["omada.example"]
+
+
+def test_authenticated_request_clears_stale_login_state_before_login():
+    """A failed login-status check does not leak stale authentication into login."""
+    session = FakeSession(
+        [
+            FakeResponse("text/html"),
+            FakeResponse(
+                "application/json",
+                {
+                    "errorCode": 0,
+                    "result": {
+                        "controllerVer": "6.2.10.17",
+                        "omadacId": "controller-id",
+                    },
+                },
+            ),
+            FakeResponse(
+                "application/json",
+                {"errorCode": 0, "result": {"token": "new-token"}},
+            ),
+            FakeResponse("application/json", {"errorCode": 0, "result": {"ok": True}}),
+        ]
+    )
+    connection = OmadaApiConnection(
+        "https://omada.example:8043", "user", "pass", session
+    )
+    connection._controller_id = "controller-id"
+    connection._csrf_token = "old-token"
+    connection._last_logon = 0
+
+    result = asyncio.run(connection.request("get", "https://omada.example/request"))
+
+    assert result == {"ok": True}
+    assert session.requests[0][2]["Csrf-Token"] == "old-token"
+    assert "Csrf-Token" not in session.requests[1][2]
+    assert "Csrf-Token" not in session.requests[2][2]
+    assert session.requests[3][2]["Csrf-Token"] == "new-token"
+    assert session.cookie_jar.cleared_domains == ["omada.example"]

--- a/uv.lock
+++ b/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "tplink-omada-client"
-version = "1.5.8"
+version = "1.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- expose software controller update details from controller/notification/updateInfo
- keep existing hardware controller update access unchanged
- show software and hardware controller updates separately in the firmware CLI
- retry authenticated requests once after Omada returns a closed login session
- add tests for hardware/software controller update payloads and session retry handling

## Why
Omada Software Controller returns available controller software upgrades in the native updateInfo payload under the software key. The existing library exposes the hardware key as typed properties, but software updates are only available through raw_data.

When the Omada controller restarts, previously authenticated sessions can be invalidated while the client still considers the login recent. Omada may then return the login page instead of JSON. Retrying the authenticated request immediately after a fresh login lets long-running clients recover without being recreated by the caller.

## Validation
- uv run ruff check src tests
- uv run pytest
- uv build
- manually tested with Home Assistant by stopping and starting the Omada Software Controller; Omada devices recovered without reloading the integration