### PR TITLE
Add site topology support and CLI command for visualization

### DIFF
--- a/src/tplink_omada_client/cli/__init__.py
+++ b/src/tplink_omada_client/cli/__init__.py
@@ -31,6 +31,7 @@ from . import (
     command_switches,
     command_target,
     command_targets,
+    command_topology,
     command_unblock_client,
     command_vpn,
     command_wan,
@@ -71,6 +72,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     command_switches.arg_parser(subparsers)
     command_target.arg_parser(subparsers)
     command_targets.arg_parser(subparsers)
+    command_topology.arg_parser(subparsers)
     command_unblock_client.arg_parser(subparsers)
     command_vpn.arg_parser(subparsers)
     command_wan.arg_parser(subparsers)

--- a/src/tplink_omada_client/cli/command_topology.py
+++ b/src/tplink_omada_client/cli/command_topology.py
@@ -1,0 +1,70 @@
+"""Implementation for 'topology' command"""
+
+from argparse import ArgumentParser
+
+from tplink_omada_client.definitions import DeviceStatusCategory, LinkSpeed
+from tplink_omada_client.topology import OmadaTopologyNode
+
+from .config import get_target_config, to_omada_connection
+from .util import dump_raw_data, get_checkbox_char, get_target_argument
+
+
+async def command_topology(args) -> int:
+    """Executes 'topology' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        topology = await site_client.get_topology()
+
+        _print_children(topology.roots, "", args)
+
+    return 0
+
+
+def _print_children(nodes: list[OmadaTopologyNode], prefix: str, args) -> None:
+    for index, node in enumerate(nodes):
+        is_last = index == len(nodes) - 1
+        connector = "└── " if is_last else "├── "
+        extension = "    " if is_last else "│   "
+
+        print(f"{prefix}{connector}{_format_node(node)}")
+        dump_raw_data(args, node)
+        _print_children(node.successors, prefix + extension, args)
+
+
+def _format_node(node: OmadaTopologyNode) -> str:
+    # "omada controller" is itself the physical controller appliance; the type label
+    # would otherwise redundantly repeat its own device name (e.g. "Omada Controller
+    # [omada controller]").
+    type_label = "controller" if node.type == "omada controller" else node.type
+    checkbox = get_checkbox_char(not node.disconnected)
+
+    if node.upstream_port is not None:
+        speed = node.upstream_link_speed.name[6:] if node.upstream_link_speed != LinkSpeed.UNKNOWN else "?"
+        port_info = f" <- port {node.upstream_port} ({checkbox} {speed})"
+    else:
+        port_info = f" ({checkbox})"
+
+    status_info = ""
+    if node.status_category not in (DeviceStatusCategory.UNKNOWN, DeviceStatusCategory.CONNECTED):
+        status_info = f" [{node.status.name} / {node.status_category.name}]"
+
+    wan_info = ""
+    if node.wan_ports:
+        summaries = [
+            f"{wan.name}: {get_checkbox_char(wan.wan_connected)} {wan.link_speed.name[6:]}" for wan in node.wan_ports
+        ]
+        wan_info = f" ({', '.join(summaries)})"
+
+    return f"{node.name} [{type_label}] {node.mac}{port_info}{status_info}{wan_info}"
+
+
+def arg_parser(subparsers) -> None:
+    """Configures arguments parser for 'topology' command"""
+    topology_parser: ArgumentParser = subparsers.add_parser(
+        "topology", help="Shows the site's physical network topology tree (device wiring map)"
+    )
+    topology_parser.set_defaults(func=command_topology)
+    topology_parser.add_argument("-d", "--dump", help="Output raw topology node information", action="store_true")

--- a/src/tplink_omada_client/cli/command_topology.py
+++ b/src/tplink_omada_client/cli/command_topology.py
@@ -41,8 +41,9 @@ def _format_node(node: OmadaTopologyNode) -> str:
     type_label = "controller" if node.type == "omada controller" else node.type
     checkbox = get_checkbox_char(not node.disconnected)
 
+    upstream_link_speed = node.upstream_link_speed
     if node.upstream_port is not None:
-        speed = node.upstream_link_speed.name[6:] if node.upstream_link_speed != LinkSpeed.UNKNOWN else "?"
+        speed = upstream_link_speed.name[6:] if upstream_link_speed != LinkSpeed.UNKNOWN else "?"
         port_info = f" <- port {node.upstream_port} ({checkbox} {speed})"
     else:
         port_info = f" ({checkbox})"
@@ -52,12 +53,12 @@ def _format_node(node: OmadaTopologyNode) -> str:
         status_info = f" [{node.status.name} / {node.status_category.name}]"
 
     wan_info = ""
-    if node.wan_ports:
+    wan_ports = node.wan_ports
+    if wan_ports:
         summaries = [
-            f"{wan.name}: {get_checkbox_char(wan.wan_connected)} {wan.link_speed.name[6:]}" for wan in node.wan_ports
+            f"{wan.name}: {get_checkbox_char(wan.wan_connected)} {wan.link_speed.name[6:]}" for wan in wan_ports
         ]
         wan_info = f" ({', '.join(summaries)})"
-
     return f"{node.name} [{type_label}] {node.mac}{port_info}{status_info}{wan_info}"
 
 

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -42,6 +42,7 @@ from .exceptions import (
     OmadaClientException,
 )
 from .omadaapiconnection import OmadaApiConnection
+from .topology import OmadaTopology
 from .vpn import _VPN_LIST_ENDPOINTS, OmadaVpnCategory, OmadaVpnPolicy
 
 
@@ -260,6 +261,13 @@ class OmadaSiteClient:
         """Get a single device by mac."""
         # So wasteful
         return next(d for d in await self.get_devices() if d.mac == mac)
+
+    async def get_topology(self) -> OmadaTopology:
+        """Get the site's physical network topology tree, rooted at its gateway(s)."""
+
+        result = await self._api.request("get", self._api.format_url("topology", self._site_id))
+
+        return OmadaTopology(result)
 
     async def get_switches(self) -> list[OmadaSwitch]:
         """Get the list of switches on the site."""

--- a/src/tplink_omada_client/topology.py
+++ b/src/tplink_omada_client/topology.py
@@ -1,0 +1,140 @@
+"""
+Definitions for the site's physical network topology tree.
+
+Unlike the device and client APIs, which report each device or client in
+isolation, the topology endpoint reports the actual physical wiring between
+managed devices (gateway, switches, APs) and their nearest recognized
+downstream nodes, including which port on the upstream device each node is
+plugged into.
+"""
+
+from .definitions import DeviceStatus, DeviceStatusCategory, LinkDuplex, LinkSpeed, LinkStatus, OmadaApiData
+
+
+class OmadaTopologyWanPort(OmadaApiData):
+    """Summary WAN port health, as reported on a gateway node in the topology tree."""
+
+    @property
+    def port(self) -> str:
+        """The port number."""
+        return self._data["port"]
+
+    @property
+    def name(self) -> str:
+        """The port name."""
+        return self._data.get("name", self.port)
+
+    @property
+    def link_status(self) -> LinkStatus:
+        """Low level connectivity status of the link."""
+        return LinkStatus(self._data.get("status", LinkStatus.UNKNOWN))
+
+    @property
+    def link_speed(self) -> LinkSpeed:
+        """The established link speed of the port."""
+        return LinkSpeed(self._data.get("linkSpeed", LinkSpeed.UNKNOWN))
+
+    @property
+    def duplex(self) -> LinkDuplex:
+        """Actual duplex mode of the port."""
+        return LinkDuplex(self._data.get("duplex", LinkDuplex.UNKNOWN))
+
+    @property
+    def wan_connected(self) -> bool:
+        """True, if the port is connected to the internet/WAN."""
+        return self._data.get("internetState", 0) != 0
+
+    @property
+    def online_detection(self) -> bool:
+        """True, if regular internet ping tests are working."""
+        return self._data.get("onlineDetection", 0) != 0
+
+
+class OmadaTopologyNode(OmadaApiData):
+    """A single node (device, or a directly-identifiable client) in the topology tree."""
+
+    @property
+    def type(self) -> str:
+        """The type of node. Known values include "gateway", "switch", "ap", and "omada controller"."""
+        return self._data["type"]
+
+    @property
+    def mac(self) -> str:
+        """The MAC address of the node."""
+        return self._data["mac"]
+
+    @property
+    def name(self) -> str:
+        """The display name of the node."""
+        return self._data.get("name", self.mac)
+
+    @property
+    def model(self) -> str | None:
+        """The model of the node, if it's a managed Omada device."""
+        return self._data.get("model")
+
+    @property
+    def ip_address(self) -> str | None:
+        """The IP address of the node, if known."""
+        return self._data.get("ip")
+
+    @property
+    def status(self) -> DeviceStatus:
+        """The status of the node, if it's a managed Omada device."""
+        return DeviceStatus(self._data.get("status", DeviceStatus.UNKNOWN))
+
+    @property
+    def status_category(self) -> DeviceStatusCategory:
+        """The high-level status of the node, if it's a managed Omada device."""
+        return DeviceStatusCategory(self._data.get("statusCategory", DeviceStatusCategory.UNKNOWN))
+
+    @property
+    def disconnected(self) -> bool:
+        """True, if the node is currently disconnected."""
+        return self._data.get("disconnected", False)
+
+    @property
+    def client_count(self) -> int:
+        """Number of clients attached to this node, if it's a managed Omada device."""
+        return self._data.get("clientCount", 0)
+
+    @property
+    def upstream_port(self) -> str | None:
+        """The port number, on the parent node, that this node is plugged into."""
+        uplink_port = self._data.get("wiredUpInfo", {}).get("upLinkPort")
+        return uplink_port.get("port") if uplink_port else None
+
+    @property
+    def own_uplink_port(self) -> str | None:
+        """The port number, on this node's own hardware, used for its uplink (switches only)."""
+        own_port = self._data.get("wiredUpInfo", {}).get("port")
+        return own_port.get("port") if own_port else None
+
+    @property
+    def upstream_link_speed(self) -> LinkSpeed:
+        """The negotiated link speed between this node and its parent."""
+        return LinkSpeed(self._data.get("wiredUpInfo", {}).get("linkSpeed", LinkSpeed.UNKNOWN))
+
+    @property
+    def upstream_duplex(self) -> LinkDuplex:
+        """The negotiated duplex mode between this node and its parent."""
+        return LinkDuplex(self._data.get("wiredUpInfo", {}).get("duplex", LinkDuplex.UNKNOWN))
+
+    @property
+    def successors(self) -> list["OmadaTopologyNode"]:
+        """The nodes plugged into this node."""
+        return [OmadaTopologyNode(s) for s in self._data.get("successors", [])]
+
+    @property
+    def wan_ports(self) -> list[OmadaTopologyWanPort]:
+        """WAN port health summaries, for gateway nodes."""
+        return [OmadaTopologyWanPort(p) for p in self._data.get("wanPorts", [])]
+
+
+class OmadaTopology(OmadaApiData):
+    """The site's full physical network topology tree, rooted at its gateway(s)."""
+
+    @property
+    def roots(self) -> list[OmadaTopologyNode]:
+        """The root nodes of the topology tree (typically the site's gateway(s))."""
+        return [OmadaTopologyNode(n) for n in self._data.get("topologyArray", [])]

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,0 +1,158 @@
+"""Tests for the site topology tree."""
+
+import asyncio
+
+from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory, LinkSpeed, LinkStatus
+from tplink_omada_client.omadasiteclient import OmadaSiteClient
+from tplink_omada_client.topology import OmadaTopology
+
+
+def _topology_data() -> dict:
+    return {
+        "topologyArray": [
+            {
+                "type": "gateway",
+                "name": "test-gateway",
+                "mac": "gateway-mac",
+                "model": "ER-TEST",
+                "ip": "192.0.2.1",
+                "status": 14,
+                "statusCategory": 1,
+                "clientCount": 0,
+                "successors": [
+                    {
+                        "type": "switch",
+                        "name": "test-switch",
+                        "mac": "switch-mac",
+                        "model": "SG-TEST",
+                        "ip": "192.0.2.2",
+                        "status": 14,
+                        "statusCategory": 1,
+                        "clientCount": 0,
+                        "successors": [],
+                        "wiredUpInfo": {
+                            "port": {"port": "1"},
+                            "upLinkPort": {"port": "4"},
+                            "linkSpeed": 3,
+                            "duplex": 2,
+                        },
+                    }
+                ],
+            }
+        ],
+        "lastUpdateTime": 1700000000000,
+    }
+
+
+class FakeApi:
+    def __init__(self, topology: dict) -> None:
+        self.topology = topology
+        self.requests = []
+
+    def format_url(self, end_point: str, site: str | None = None) -> str:
+        return f"api/{site}/{end_point}"
+
+    async def request(self, method: str, url: str, params=None, json=None, data=None):
+        self.requests.append((method, url))
+        if method == "get" and url.endswith("/topology"):
+            return self.topology
+        raise AssertionError(f"Unexpected request: {method} {url}")
+
+
+def test_get_topology_returns_root_nodes():
+    api = FakeApi(_topology_data())
+    client = OmadaSiteClient("site-id", api)
+
+    topology = asyncio.run(client.get_topology())
+
+    assert isinstance(topology, OmadaTopology)
+    assert api.requests == [("get", "api/site-id/topology")]
+    assert len(topology.roots) == 1
+    assert topology.roots[0].name == "test-gateway"
+    assert topology.roots[0].type == "gateway"
+    assert topology.roots[0].status_category == DeviceStatusCategory.CONNECTED
+
+
+def test_topology_node_exposes_upstream_port_and_link_speed():
+    topology = OmadaTopology(_topology_data())
+
+    switch = topology.roots[0].successors[0]
+
+    assert switch.name == "test-switch"
+    assert switch.mac == "switch-mac"
+    assert switch.own_uplink_port == "1"
+    assert switch.upstream_port == "4"
+    assert switch.upstream_link_speed == LinkSpeed.SPEED_1_GBPS
+    assert switch.successors == []
+
+
+def test_topology_node_defaults_missing_fields_to_unknown():
+    node_data = {"type": "ap", "mac": "ap-mac"}
+    topology = OmadaTopology({"topologyArray": [node_data]})
+
+    node = topology.roots[0]
+
+    assert node.name == "ap-mac"
+    assert node.model is None
+    assert node.ip_address is None
+    assert node.upstream_port is None
+    assert node.upstream_link_speed == LinkSpeed.UNKNOWN
+    assert node.status_category == DeviceStatusCategory.UNKNOWN
+
+
+def test_topology_node_disconnected_defaults_to_false():
+    node_data = {"type": "ap", "mac": "ap-mac"}
+    topology = OmadaTopology({"topologyArray": [node_data]})
+
+    assert topology.roots[0].disconnected is False
+
+
+def test_topology_node_reports_disconnected_when_flagged():
+    node_data = {"type": "ap", "mac": "ap-mac", "disconnected": True}
+    topology = OmadaTopology({"topologyArray": [node_data]})
+
+    assert topology.roots[0].disconnected is True
+
+
+def test_topology_node_reports_non_connected_status():
+    node_data = {"type": "ap", "mac": "ap-mac", "status": 13, "statusCategory": 0}
+    topology = OmadaTopology({"topologyArray": [node_data]})
+
+    node = topology.roots[0]
+
+    assert node.status == DeviceStatus.REBOOTING
+    assert node.status_category == DeviceStatusCategory.DISCONNECTED
+
+
+def test_topology_node_has_no_wan_ports_when_not_a_gateway():
+    node_data = {"type": "ap", "mac": "ap-mac"}
+    topology = OmadaTopology({"topologyArray": [node_data]})
+
+    assert topology.roots[0].wan_ports == []
+
+
+def test_topology_gateway_exposes_wan_port_summary():
+    node_data = {
+        "type": "gateway",
+        "mac": "gateway-mac",
+        "wanPorts": [
+            {
+                "port": "1",
+                "name": "WAN1",
+                "status": 1,
+                "internetState": 1,
+                "onlineDetection": 1,
+                "linkSpeed": 3,
+                "duplex": 2,
+            }
+        ],
+    }
+    topology = OmadaTopology({"topologyArray": [node_data]})
+
+    wan_port = topology.roots[0].wan_ports[0]
+
+    assert wan_port.name == "WAN1"
+    assert wan_port.link_status == LinkStatus.LINK_UP
+    assert wan_port.link_speed == LinkSpeed.SPEED_1_GBPS
+    assert wan_port.wan_connected is True
+    assert wan_port.online_detection is True


### PR DESCRIPTION
This pull request introduces a new `topology` command to the CLI, along with supporting backend and test code, to expose and interact with the site's physical network topology tree. The main changes include implementing the topology data model, adding the API endpoint to retrieve topology, integrating the new command into the CLI, and comprehensive tests to ensure correct behavior.

**New CLI Command and API Integration:**

* Added a new `topology` command to the CLI, which displays the site's physical network topology tree, including device wiring and port information. (`src/tplink_omada_client/cli/command_topology.py`)
* Integrated the new command into the CLI's argument parser and command list. (`src/tplink_omada_client/cli/__init__.py`) [[1]](diffhunk://#diff-4dc938f8ae0f8342c9aa2a66717b05079f68e9ae85fba86ea979f5fbec365621R34) [[2]](diffhunk://#diff-4dc938f8ae0f8342c9aa2a66717b05079f68e9ae85fba86ea979f5fbec365621R75)

**Backend and Data Model Enhancements:**

* Implemented the `OmadaTopology`, `OmadaTopologyNode`, and `OmadaTopologyWanPort` classes to represent and parse the physical topology tree, including device and port details. (`src/tplink_omada_client/topology.py`)
* Added the `get_topology` method to `OmadaSiteClient` to fetch and return the topology data from the controller API. (`src/tplink_omada_client/omadasiteclient.py`) [[1]](diffhunk://#diff-95f0ee41b648fe243ac0cd3873a5ab420b3c7920c284861ce8f202bd17355121R45) [[2]](diffhunk://#diff-95f0ee41b648fe243ac0cd3873a5ab420b3c7920c284861ce8f202bd17355121R265-R271)

**Testing:**

* Added comprehensive tests for the topology data structures and the new API method, covering various scenarios and edge cases. (`tests/test_topology.py`)