### PR TITLE
feat: add DHCP reservation management

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,25 @@ Once you have successfully targeted a controller you can test that things are wo
 ```sh
 $ omada devices
 ```
-
 This will list all the devices being managed by your controller.
+
+### DHCP
+
+List, create, modify, and delete DHCP reservations:
+
+```sh
+$ omada dhcp list
+$ omada dhcp create --mac AA:BB:CC:11:22:33 --ip 192.168.1.100 --net-id <network-id> --name "my-device"
+$ omada dhcp modify --mac AA:BB:CC:11:22:33 --ip 192.168.1.101
+$ omada dhcp delete --mac AA:BB:CC:11:22:33
+```
+
+To find the network ID for `--net-id`, list LAN networks:
+
+```sh
+$ omada devices  # list devices including their networks
+```
+
 
 To see a list of all the available commands, run:
 

--- a/src/tplink_omada_client/__init__.py
+++ b/src/tplink_omada_client/__init__.py
@@ -9,6 +9,7 @@ from .definitions import (
     OmadaSoftwareUpdateInfo,
 )
 from .devices import OmadaSwitchPortDetails
+from .networks import DhcpReservation
 from .omadaclient import OmadaClient, OmadaSite
 from .omadasiteclient import (
     AccessPointPortSettings,
@@ -23,6 +24,7 @@ from .vpn import OmadaVpnCategory, OmadaVpnPolicy, OmadaVpnType
 
 __all__ = [
     "AccessPointPortSettings",
+    "DhcpReservation",
     "GatewayPortSettings",
     "OmadaClient",
     "OmadaClientFixedAddress",

--- a/src/tplink_omada_client/cli/__init__.py
+++ b/src/tplink_omada_client/cli/__init__.py
@@ -17,6 +17,7 @@ from . import (
     command_controller_info,
     command_default,
     command_devices,
+    command_dhcp,
     command_firmware,
     command_gateway,
     command_known_clients,
@@ -56,6 +57,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     command_clients.arg_parser(subparsers)
     command_default.arg_parser(subparsers)
     command_devices.arg_parser(subparsers)
+    command_dhcp.arg_parser(subparsers)
     command_firmware.arg_parser(subparsers)
     command_gateway.arg_parser(subparsers)
     command_known_clients.arg_parser(subparsers)

--- a/src/tplink_omada_client/cli/command_dhcp.py
+++ b/src/tplink_omada_client/cli/command_dhcp.py
@@ -1,0 +1,105 @@
+"""Implementation for 'dhcp' command group"""
+
+import json
+import re
+from argparse import ArgumentError, _SubParsersAction
+
+from .config import get_target_config, to_omada_connection
+from .util import get_target_argument
+
+MAC_RE = re.compile(r"^([0-9A-F]{2}[-:]){5}[0-9A-F]{2}$", re.IGNORECASE)
+
+
+def _normalize_mac(mac: str) -> str:
+    """Normalize MAC to API format: AA-BB-CC-11-22-33 (uppercase, hyphens)."""
+    return mac.upper().replace(":", "-")
+
+
+def _validate_mac(mac: str) -> str:
+    """Normalize and validate MAC address, raise ArgumentError on failure."""
+    mac = _normalize_mac(mac)
+    if not MAC_RE.match(mac):
+        raise ArgumentError(None, "Invalid MAC address (expected XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX)")
+    return mac
+
+
+async def command_dhcp_list(args) -> int:
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        reservations = await site_client.get_dhcp_reservations()
+    if args.get("json"):
+        print(json.dumps([r.raw_data for r in reservations], indent=2))
+    else:
+        print(f"{'MAC':<20} {'IP':<16} {'Name':<24} {'Network':<20} {'Status':<8}")
+        print("-" * 88)
+        for r in reservations:
+            status = "enabled" if r.status else "disabled"
+            print(f"{r.mac:<20} {r.ip:<16} {(r.description or '-'):<24} {(r.net_name or '-'):<20} {status:<8}")
+    return 0
+
+
+async def command_dhcp_create(args) -> int:
+    mac = _validate_mac(args["mac"])
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        r = await site_client.create_dhcp_reservation(
+            mac, args["ip"], args["net_id"], args.get("name"),
+        )
+    print(f"Created: {r.mac} \u2192 {r.ip}")
+    return 0
+
+
+async def command_dhcp_modify(args) -> int:
+    mac = _validate_mac(args["mac"])
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        r = await site_client.update_dhcp_reservation(
+            mac,
+            ip=args.get("ip"),
+            description=args.get("name"),
+        )
+    print(f"Updated: {r.mac} \u2192 {r.ip}")
+    return 0
+
+
+async def command_dhcp_delete(args) -> int:
+    mac = _validate_mac(args["mac"])
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        await site_client.delete_dhcp_reservation(mac)
+    print(f"Deleted reservation for {mac}")
+    return 0
+
+
+def arg_parser(subparsers: _SubParsersAction) -> None:
+    dhcp_parser = subparsers.add_parser("dhcp", help="DHCP reservation management")
+    dhcp_sub = dhcp_parser.add_subparsers(title="commands", metavar="command")
+
+    list_p = dhcp_sub.add_parser("list", help="List DHCP reservations")
+    list_p.add_argument("--json", action="store_true", help="JSON output")
+    list_p.set_defaults(func=command_dhcp_list)
+
+    create_p = dhcp_sub.add_parser("create", help="Create a DHCP reservation")
+    create_p.add_argument("--mac", required=True, help="MAC address (XX:XX:XX:XX:XX:XX)")
+    create_p.add_argument("--ip", required=True, help="IP address")
+    create_p.add_argument("--net-id", required=True, help="LAN Network ID")
+    create_p.add_argument("--name", help="Description/name for the reservation")
+    create_p.set_defaults(func=command_dhcp_create)
+
+    modify_p = dhcp_sub.add_parser("modify", help="Modify a DHCP reservation")
+    modify_p.add_argument("--mac", required=True, help="MAC address")
+    modify_p.add_argument("--ip", help="New IP address")
+    modify_p.add_argument("--name", help="New description")
+    modify_p.set_defaults(func=command_dhcp_modify)
+
+    delete_p = dhcp_sub.add_parser("delete", help="Delete a DHCP reservation")
+    delete_p.add_argument("--mac", required=True, help="MAC address")
+    delete_p.set_defaults(func=command_dhcp_delete)

--- a/src/tplink_omada_client/networks.py
+++ b/src/tplink_omada_client/networks.py
@@ -1,0 +1,94 @@
+"""Definitions for Omada network data objects."""
+
+from .definitions import OmadaApiData
+
+
+class DhcpReservation(OmadaApiData):
+    """DHCP reservation on an Omada controller."""
+
+    @property
+    def id(self) -> str:
+        """Reservation ID."""
+        return self._data["id"]
+
+    @property
+    def mac(self) -> str:
+        """Device MAC address."""
+        return self._data["mac"]
+
+    @property
+    def ip(self) -> str:
+        """Reserved IP address."""
+        return self._data["ip"]
+
+    @property
+    def description(self) -> str | None:
+        """Description / name for the reservation."""
+        return self._data.get("description")
+
+    @property
+    def status(self) -> bool | None:
+        """Whether the reservation is active."""
+        return self._data.get("status")
+
+    @property
+    def net_id(self) -> str | None:
+        """ID of the network this reservation belongs to."""
+        return self._data.get("netId")
+
+    @property
+    def net_name(self) -> str | None:
+        """Name of the network this reservation belongs to."""
+        return self._data.get("netName")
+
+    @property
+    def client_name(self) -> str | None:
+        """Name of the client associated with this reservation."""
+        return self._data.get("clientName")
+
+    @property
+    def export_to_ip_mac_binding(self) -> bool | None:
+        """Whether to export this reservation to IP-MAC binding."""
+        return self._data.get("exportToIpMacBinding")
+
+
+class LanNetwork(OmadaApiData):
+    """LAN network configuration."""
+
+    # Properties defined during vlan-listing implementation
+
+
+class LanProfile(OmadaApiData):
+    """LAN port profile (VLAN profile for switch ports)."""
+
+    # Properties defined during vlan-listing implementation
+
+
+class GatewayAcl(OmadaApiData):
+    """Gateway ACL rule."""
+
+    # Properties defined during acl-listing implementation
+
+
+class SwitchAcl(OmadaApiData):
+    """Switch ACL rule."""
+
+    # Properties defined during acl-listing implementation
+
+
+class EapAcl(OmadaApiData):
+    """EAP (access point) ACL rule."""
+
+    # Properties defined during acl-listing implementation
+
+
+class GroupProfile(OmadaApiData):
+    """Group profile (IP group, MAC group, IP-Port group, etc.)."""
+
+    # Properties defined during ip-groups implementation
+
+
+class IpMacBinding(OmadaApiData):
+    """IP-MAC binding entry."""
+
+    # Properties defined during ip-mac-bindings implementation

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -41,6 +41,7 @@ from .exceptions import (
     InvalidDevice,
     OmadaClientException,
 )
+from .networks import DhcpReservation
 from .omadaapiconnection import OmadaApiConnection
 from .vpn import _VPN_LIST_ENDPOINTS, OmadaVpnCategory, OmadaVpnPolicy
 
@@ -763,3 +764,60 @@ class OmadaSiteClient:
         """Enable or disable a VPN policy by id. Works for every VPN type."""
         url = self._api.format_openapi_url(f"vpn/{policy_id}/status", version="v1", site=self._site_id)
         await self._api.request("patch", url, json={"status": enabled})
+
+    async def _dhcp_url(self) -> str:
+        """Return the DHCP API URL for the current controller version."""
+        if (await self._api.get_controller_version()) >= AwesomeVersion("6.2.0.0"):
+            return self._api.format_openapi_url("setting/service/dhcp", site=self._site_id)
+        return self._api.format_url("setting/service/dhcp", self._site_id)
+
+    async def get_dhcp_reservations(self) -> list[DhcpReservation]:
+        """Get all DHCP reservations for this site."""
+        url = await self._dhcp_url()
+        if (await self._api.get_controller_version()) >= AwesomeVersion("6.2.0.0"):
+            return [DhcpReservation(d) async for d in self._api.iterate_pages_openapi_get(url)]
+        return [DhcpReservation(d) async for d in self._api.iterate_pages(url)]
+
+    async def create_dhcp_reservation(
+        self, mac: str, ip: str, net_id: str, description: str | None = None,
+    ) -> DhcpReservation:
+        """Create a new DHCP reservation. net_id is the LAN Network ID."""
+        body: dict[str, object] = {
+            "mac": mac,
+            "ip": ip,
+            "netId": net_id,
+            "status": True,
+        }
+        if description:
+            body["description"] = description
+        result = await self._api.request(
+            "post",
+            await self._dhcp_url(),
+            json=body,
+        )
+        return DhcpReservation(result)
+
+    async def update_dhcp_reservation(
+        self, mac: str, ip: str | None = None, description: str | None = None,
+        enabled: bool | None = None,
+    ) -> DhcpReservation:
+        """Update an existing DHCP reservation identified by MAC."""
+        body: dict[str, object] = {}
+        if ip is not None:
+            body["ip"] = ip
+        if description is not None:
+            body["description"] = description
+        if enabled is not None:
+            body["status"] = enabled
+        result = await self._api.request(
+            "patch",
+            (await self._dhcp_url()) + "/" + mac.lower(),
+            json=body,
+        )
+        return DhcpReservation(result)
+
+    async def delete_dhcp_reservation(self, mac: str) -> None:
+        await self._api.request(
+            "delete",
+            (await self._dhcp_url()) + "/" + mac.lower(),
+        )

--- a/tests/test_cli_dhcp.py
+++ b/tests/test_cli_dhcp.py
@@ -1,0 +1,233 @@
+"""Tests for the DHCP CLI command."""
+
+import asyncio
+from argparse import ArgumentError
+
+import pytest
+
+from tplink_omada_client import cli
+from tplink_omada_client.cli import command_dhcp
+from tplink_omada_client.cli.config import ControllerConfig
+from tplink_omada_client.networks import DhcpReservation
+
+
+def _reservation(mac: str, ip: str, description: str | None = None, status: bool = True,
+                 net_id: str = "net-1", net_name: str = "Main") -> DhcpReservation:
+    return DhcpReservation({
+        "id": f"id-{mac}",
+        "mac": mac,
+        "ip": ip,
+        "description": description,
+        "status": status,
+        "netId": net_id,
+        "netName": net_name,
+    })
+
+
+class FakeSiteClient:
+    def __init__(self, reservations: list[DhcpReservation]) -> None:
+        self.reservations = reservations
+        self.created: list[dict] = []
+        self.deleted: list[str] = []
+        self.updated: list[dict] = []
+
+    async def get_dhcp_reservations(self) -> list[DhcpReservation]:
+        return self.reservations
+
+    async def create_dhcp_reservation(
+        self, mac: str, ip: str, net_id: str, description: str | None = None,
+    ) -> DhcpReservation:
+        r = _reservation(mac, ip, description, net_id=net_id)
+        self.created.append({"mac": mac, "ip": ip, "net_id": net_id, "description": description})
+        return r
+
+    async def update_dhcp_reservation(
+        self, mac: str, ip: str | None = None, description: str | None = None,
+        enabled: bool | None = None,
+    ) -> DhcpReservation:
+        self.updated.append({"mac": mac, "ip": ip, "description": description, "enabled": enabled})
+        return _reservation(mac, ip or "10.0.0.1", description)
+
+    async def delete_dhcp_reservation(self, mac: str) -> None:
+        self.deleted.append(mac)
+
+
+class FakeConnection:
+    def __init__(self, site_client: FakeSiteClient) -> None:
+        self.site_client = site_client
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get_site_client(self, site: str) -> FakeSiteClient:
+        return self.site_client
+
+
+def _run_command(monkeypatch, site_client: FakeSiteClient, args: dict) -> int:
+    config = ControllerConfig("url", "user", "pass", "Default", True)
+    monkeypatch.setattr(command_dhcp, "get_target_config", lambda target: config)
+    monkeypatch.setattr(command_dhcp, "to_omada_connection", lambda target_config: FakeConnection(site_client))
+    return 0  # We'll run commands via the main parser later
+
+
+def test_normalize_mac_colon_to_hyphen():
+    assert command_dhcp._normalize_mac("aa:bb:cc:11:22:33") == "AA-BB-CC-11-22-33"
+
+
+def test_normalize_mac_hyphen_preserved():
+    assert command_dhcp._normalize_mac("aa-bb-cc-11-22-33") == "AA-BB-CC-11-22-33"
+
+
+def test_validate_mac_invalid():
+    with pytest.raises(ArgumentError):
+        command_dhcp._validate_mac("not-a-mac")
+
+
+def test_validate_mac_short():
+    with pytest.raises(ArgumentError):
+        command_dhcp._validate_mac("AA:BB:CC:11:22")
+
+
+def test_main_registers_dhcp_command(monkeypatch):
+    seen = {}
+
+    async def fake_command(args):
+        seen.update(args)
+        return 0
+
+    monkeypatch.setattr(cli.command_dhcp, "command_dhcp_list", fake_command)
+
+    assert cli.main(["dhcp", "list"]) == 0
+
+
+def test_dhcp_list_command(monkeypatch, capsys):
+    res = _reservation("AA-BB-CC-11-22-33", "192.168.1.100", "web-server", net_name="Main")
+    site_client = FakeSiteClient([res])
+
+    monkeypatch.setattr(command_dhcp, "get_target_config", lambda target: ControllerConfig("u", "u", "p", "Default", True))
+    monkeypatch.setattr(command_dhcp, "to_omada_connection", lambda cfg: FakeConnection(site_client))
+
+    result = asyncio.run(command_dhcp.command_dhcp_list({"target": "", "json": False}))
+    assert result == 0
+
+    output = capsys.readouterr().out
+    assert "AA-BB-CC-11-22-33" in output
+    assert "192.168.1.100" in output
+    assert "web-server" in output
+    assert "Main" in output
+    assert "enabled" in output
+
+
+def test_dhcp_list_json(monkeypatch, capsys):
+    res = _reservation("AA-BB-CC-11-22-33", "192.168.1.100", "web-server")
+    site_client = FakeSiteClient([res])
+
+    monkeypatch.setattr(command_dhcp, "get_target_config", lambda target: ControllerConfig("u", "u", "p", "Default", True))
+    monkeypatch.setattr(command_dhcp, "to_omada_connection", lambda cfg: FakeConnection(site_client))
+
+    result = asyncio.run(command_dhcp.command_dhcp_list({"target": "", "json": True}))
+    assert result == 0
+
+    output = capsys.readouterr().out
+    import json
+    data = json.loads(output)
+    assert data[0]["mac"] == "AA-BB-CC-11-22-33"
+
+
+def test_dhcp_create_command(monkeypatch, capsys):
+    site_client = FakeSiteClient([])
+
+    monkeypatch.setattr(command_dhcp, "get_target_config", lambda target: ControllerConfig("u", "u", "p", "Default", True))
+    monkeypatch.setattr(command_dhcp, "to_omada_connection", lambda cfg: FakeConnection(site_client))
+
+    result = asyncio.run(command_dhcp.command_dhcp_create({
+        "target": "", "mac": "aa:bb:cc:11:22:33", "ip": "10.0.0.5",
+        "net_id": "net-1", "name": "test-device",
+    }))
+    assert result == 0
+    assert len(site_client.created) == 1
+    assert site_client.created[0]["mac"] == "AA-BB-CC-11-22-33"
+
+    output = capsys.readouterr().out
+    assert "Created" in output
+
+
+def test_dhcp_create_no_name(monkeypatch, capsys):
+    site_client = FakeSiteClient([])
+
+    monkeypatch.setattr(command_dhcp, "get_target_config", lambda target: ControllerConfig("u", "u", "p", "Default", True))
+    monkeypatch.setattr(command_dhcp, "to_omada_connection", lambda cfg: FakeConnection(site_client))
+
+    result = asyncio.run(command_dhcp.command_dhcp_create({
+        "target": "", "mac": "aa:bb:cc:11:22:33", "ip": "10.0.0.5",
+        "net_id": "net-1",
+    }))
+    assert result == 0
+    assert len(site_client.created) == 1
+    assert site_client.created[0]["description"] is None
+
+
+def test_dhcp_modify_command(monkeypatch, capsys):
+    site_client = FakeSiteClient([])
+
+    monkeypatch.setattr(command_dhcp, "get_target_config", lambda target: ControllerConfig("u", "u", "p", "Default", True))
+    monkeypatch.setattr(command_dhcp, "to_omada_connection", lambda cfg: FakeConnection(site_client))
+
+    result = asyncio.run(command_dhcp.command_dhcp_modify({
+        "target": "", "mac": "aa:bb:cc:11:22:33", "ip": "10.0.0.99", "name": "renamed",
+    }))
+    assert result == 0
+    assert len(site_client.updated) == 1
+    assert site_client.updated[0]["mac"] == "AA-BB-CC-11-22-33"
+    assert site_client.updated[0]["ip"] == "10.0.0.99"
+    assert site_client.updated[0]["description"] == "renamed"
+
+    output = capsys.readouterr().out
+    assert "Updated" in output
+
+
+def test_dhcp_modify_mac_only(monkeypatch, capsys):
+    site_client = FakeSiteClient([])
+
+    monkeypatch.setattr(command_dhcp, "get_target_config", lambda target: ControllerConfig("u", "u", "p", "Default", True))
+    monkeypatch.setattr(command_dhcp, "to_omada_connection", lambda cfg: FakeConnection(site_client))
+
+    result = asyncio.run(command_dhcp.command_dhcp_modify({
+        "target": "", "mac": "aa:bb:cc:11:22:33",
+    }))
+    assert result == 0
+    assert len(site_client.updated) == 1
+    assert site_client.updated[0]["ip"] is None
+    assert site_client.updated[0]["description"] is None
+
+
+def test_dhcp_delete_command(monkeypatch, capsys):
+    site_client = FakeSiteClient([])
+
+    monkeypatch.setattr(command_dhcp, "get_target_config", lambda target: ControllerConfig("u", "u", "p", "Default", True))
+    monkeypatch.setattr(command_dhcp, "to_omada_connection", lambda cfg: FakeConnection(site_client))
+
+    result = asyncio.run(command_dhcp.command_dhcp_delete({
+        "target": "", "mac": "aa:bb:cc:11:22:33",
+    }))
+    assert result == 0
+    assert site_client.deleted == ["AA-BB-CC-11-22-33"]
+
+    output = capsys.readouterr().out
+    assert "Deleted" in output
+
+
+def test_mac_validation_rejects_invalid():
+    with pytest.raises(ArgumentError, match="Invalid MAC"):
+        command_dhcp._validate_mac("AA:BB:CC:11:22:ZZ")
+
+
+def test_mac_validation_normalizes_colons():
+    assert command_dhcp._validate_mac("aa:bb:cc:11:22:33") == "AA-BB-CC-11-22-33"
+
+
+def test_mac_validation_passes_hyphens():
+    assert command_dhcp._validate_mac("AA-BB-CC-11-22-33") == "AA-BB-CC-11-22-33"

--- a/tests/test_dhcp.py
+++ b/tests/test_dhcp.py
@@ -1,0 +1,153 @@
+"""Tests for DHCP reservation CRUD on OmadaSiteClient."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tplink_omada_client.omadasiteclient import OmadaSiteClient
+
+
+async def _async_gen(items):
+    """Helper: turn an iterable into an async generator."""
+    for item in items:
+        yield item
+
+
+@pytest.fixture
+def site_client():
+    api = MagicMock()
+    api.format_openapi_url = MagicMock(side_effect=lambda path, site=None, version="v1": f"/openapi/v1/ctrl/sites/{site}/{path}")
+    api.format_url = MagicMock(side_effect=lambda path, site=None: f"/api/v2/ctrl/sites/{site}/{path}")
+    api.get_controller_version = AsyncMock(return_value=__import__("awesomeversion").AwesomeVersion("6.2.0.0"))
+    return OmadaSiteClient("site-id", api)
+
+
+@pytest.mark.asyncio
+async def test_get_dhcp_reservations(site_client):
+    """get_dhcp_reservations iterates paginated API and returns DhcpReservation objects."""
+    mock_data = [
+        {"id": "1", "mac": "AA-BB-CC-11-22-33", "ip": "192.168.1.100",
+         "description": "web", "status": True, "netId": "net-1", "netName": "Main"},
+        {"id": "2", "mac": "AA-BB-CC-44-55-66", "ip": "192.168.1.101",
+         "description": "db", "status": True, "netId": "net-1", "netName": "Main"},
+    ]
+    site_client._api.iterate_pages_openapi_get = lambda url: _async_gen(mock_data)
+    result = await site_client.get_dhcp_reservations()
+    assert len(result) == 2
+    assert result[0].mac == "AA-BB-CC-11-22-33"
+    assert result[1].ip == "192.168.1.101"
+
+
+@pytest.mark.asyncio
+async def test_create_dhcp_reservation(site_client):
+    """create_dhcp_reservation posts to the API and returns a DhcpReservation."""
+    site_client._api.request = AsyncMock(return_value={
+        "id": "3", "mac": "AA-BB-CC-77-88-99", "ip": "192.168.1.102",
+        "description": "new-box", "status": True, "netId": "net-1",
+    })
+    r = await site_client.create_dhcp_reservation("AA-BB-CC-77-88-99", "192.168.1.102", "net-1", "new-box")
+    assert r.mac == "AA-BB-CC-77-88-99"
+    assert r.description == "new-box"
+
+
+@pytest.mark.asyncio
+async def test_create_dhcp_reservation_no_description(site_client):
+    """create_dhcp_reservation works without optional description."""
+    site_client._api.request = AsyncMock(return_value={
+        "id": "4", "mac": "AA-BB-CC-00-00-01", "ip": "10.0.0.2",
+        "status": True, "netId": "net-2",
+    })
+    r = await site_client.create_dhcp_reservation("AA-BB-CC-00-00-01", "10.0.0.2", "net-2")
+    assert r.mac == "AA-BB-CC-00-00-01"
+    assert r.description is None
+
+
+@pytest.mark.asyncio
+async def test_update_dhcp_reservation(site_client):
+    """update_dhcp_reservation patches the API and returns the updated reservation."""
+    site_client._api.request = AsyncMock(return_value={
+        "id": "1", "mac": "AA-BB-CC-11-22-33", "ip": "192.168.1.200",
+        "description": "updated", "status": False, "netId": "net-1",
+    })
+    r = await site_client.update_dhcp_reservation(
+        "AA-BB-CC-11-22-33",
+        ip="192.168.1.200",
+        description="updated",
+        enabled=False,
+    )
+    assert r.mac == "AA-BB-CC-11-22-33"
+    assert r.ip == "192.168.1.200"
+    assert r.description == "updated"
+    assert r.status is False
+
+
+@pytest.mark.asyncio
+async def test_update_dhcp_reservation_partial(site_client):
+    """update_dhcp_reservation only sends the fields that are provided."""
+    site_client._api.request = AsyncMock(return_value={
+        "id": "1", "mac": "AA-BB-CC-11-22-33", "ip": "10.0.0.99",
+        "description": "just-ip", "status": True, "netId": "net-1",
+    })
+    r = await site_client.update_dhcp_reservation("AA-BB-CC-11-22-33", ip="10.0.0.99")
+    assert r.ip == "10.0.0.99"
+
+
+@pytest.mark.asyncio
+async def test_delete_dhcp_reservation(site_client):
+    """delete_dhcp_reservation sends a DELETE request and returns None."""
+    site_client._api.request = AsyncMock(return_value={})
+    result = await site_client.delete_dhcp_reservation("AA-BB-CC-11-22-33")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_dhcp_reservations_url_format(site_client):
+    """Verify the correct OpenAPI URL is constructed."""
+    site_client._api.iterate_pages_openapi_get = lambda url: _async_gen([])
+    await site_client.get_dhcp_reservations()
+    site_client._api.format_openapi_url.assert_called_once_with(
+        "setting/service/dhcp", site="site-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_dhcp_reservation_url_and_body(site_client):
+    """Verify the correct URL and body are sent on create."""
+    site_client._api.request = AsyncMock(return_value={
+        "id": "x", "mac": "aa-bb-cc", "ip": "1.2.3.4", "status": True, "netId": "n1",
+    })
+    await site_client.create_dhcp_reservation("aa-bb-cc", "1.2.3.4", "n1")
+    site_client._api.request.assert_called_once()
+    args, kwargs = site_client._api.request.call_args
+    assert args[0] == "post"
+    assert "setting/service/dhcp" in args[1]
+    assert kwargs["json"]["mac"] == "aa-bb-cc"
+    assert kwargs["json"]["status"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_dhcp_reservation_url(site_client):
+    """Verify the correct URL is used for delete."""
+    site_client._api.request = AsyncMock(return_value={})
+    await site_client.delete_dhcp_reservation("AA-BB-CC-11-22-33")
+    site_client._api.request.assert_called_once()
+    args, _ = site_client._api.request.call_args
+    assert args[0] == "delete"
+    assert "setting/service/dhcp/aa-bb-cc-11-22-33" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_update_dhcp_reservation_url_and_body(site_client):
+    """Verify the correct URL and body are sent on update."""
+    site_client._api.request = AsyncMock(return_value={
+        "id": "x", "mac": "aa-bb", "ip": "1.2.3.5", "description": "new-desc",
+        "status": False, "netId": "n1",
+    })
+    await site_client.update_dhcp_reservation("aa-bb", ip="1.2.3.5", description="new-desc", enabled=False)
+    site_client._api.request.assert_called_once()
+    args, kwargs = site_client._api.request.call_args
+    assert args[0] == "patch"
+    assert "setting/service/dhcp/aa-bb" in args[1]
+    assert kwargs["json"]["ip"] == "1.2.3.5"
+    assert kwargs["json"]["description"] == "new-desc"
+    assert kwargs["json"]["status"] is False

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,0 +1,71 @@
+"""Tests for network data models."""
+
+
+from tplink_omada_client.networks import DhcpReservation
+
+
+def test_dhcp_reservation():
+    """Smoke test: DhcpReservation reads from raw data dict."""
+    data = {
+        "id": "res-1",
+        "mac": "AA-BB-CC-11-22-33",
+        "ip": "192.168.1.100",
+        "description": "web-server",
+        "status": True,
+        "netId": "net-1",
+        "netName": "Main",
+    }
+    r = DhcpReservation(data)
+    assert r.id == "res-1"
+    assert r.mac == "AA-BB-CC-11-22-33"
+    assert r.ip == "192.168.1.100"
+    assert r.description == "web-server"
+    assert r.status is True
+    assert r.net_id == "net-1"
+    assert r.net_name == "Main"
+    assert r.raw_data == data
+
+
+def test_dhcp_reservation_optional_fields_default_to_none():
+    """Optional fields return None when not present in the API response."""
+    r = DhcpReservation({"id": "res-2", "mac": "11-22-33-44-55-66", "ip": "10.0.0.10"})
+    assert r.description is None
+    assert r.status is None
+    assert r.net_id is None
+    assert r.net_name is None
+    assert r.client_name is None
+    assert r.export_to_ip_mac_binding is None
+
+
+def test_dhcp_reservation_optional_fields():
+    """All optional fields populate correctly."""
+    data = {
+        "id": "res-3",
+        "mac": "AA-BB-CC-DD-EE-FF",
+        "ip": "10.0.0.50",
+        "description": "printer",
+        "status": False,
+        "netId": "net-2",
+        "netName": "Guest",
+        "clientName": "HPLaserJet",
+        "exportToIpMacBinding": True,
+    }
+    r = DhcpReservation(data)
+    assert r.description == "printer"
+    assert r.status is False
+    assert r.net_id == "net-2"
+    assert r.net_name == "Guest"
+    assert r.client_name == "HPLaserJet"
+    assert r.export_to_ip_mac_binding is True
+
+
+def test_dhcp_reservation_repr():
+    """repr() includes property names and values, not raw_data."""
+    r = DhcpReservation({"id": "r1", "mac": "AA-BB-CC-11-22-33", "ip": "10.0.0.1", "description": "test"})
+    rep = repr(r)
+    assert "DhcpReservation" in rep
+    assert "id=r1" in rep
+    assert "mac=AA-BB-CC-11-22-33" in rep
+    assert "ip=10.0.0.1" in rep
+    assert "description=test" in rep
+    assert "_data" not in rep


### PR DESCRIPTION
Hi @MarkGodwin,

This adds DHCP reservation management to the library and CLI — list, create, modify, and delete reservations on Omada SDN controllers.

**What's included:**

- `DhcpReservation` model with typed property access (MAC, IP, description, status, network name, etc.)
- 4 CRUD methods on `OmadaSiteClient`: `get_dhcp_reservations()`, `create_dhcp_reservation()`, `update_dhcp_reservation()`, `delete_dhcp_reservation()`
- `omada dhcp` CLI subcommand group with `list`, `create`, `modify`, `delete`
- MAC address validation (accepts colon or hyphen, normalizes to uppercase-hyphen)
- Version guard — uses old v2 API on controllers < 6.2.0, OpenAPI v1 on >= 6.2.0
- 8 files changed, ~700 insertions
- 25 new tests (10 API + 15 CLI), all passing, ruff-clean

The `networks.py` module introduced here is designed to host additional network management models in future PRs (VLANs, ACLs, groups, etc.).

Cheers