### PR TITLE
Add access point radio settings support

### DIFF
--- a/src/tplink_omada_client/__init__.py
+++ b/src/tplink_omada_client/__init__.py
@@ -12,6 +12,7 @@ from .devices import OmadaSwitchPortDetails
 from .omadaclient import OmadaClient, OmadaSite
 from .omadasiteclient import (
     AccessPointPortSettings,
+    AccessPointRadioSettings,
     GatewayPortSettings,
     OmadaClientFixedAddress,
     OmadaClientSettings,
@@ -23,6 +24,7 @@ from .vpn import OmadaVpnCategory, OmadaVpnPolicy, OmadaVpnType
 
 __all__ = [
     "AccessPointPortSettings",
+    "AccessPointRadioSettings",
     "GatewayPortSettings",
     "OmadaClient",
     "OmadaClientFixedAddress",

--- a/src/tplink_omada_client/cli/__init__.py
+++ b/src/tplink_omada_client/cli/__init__.py
@@ -24,6 +24,7 @@ from . import (
     command_port_profiles,
     command_reboot,
     command_reconnect_client,
+    command_set_ap_radio,
     command_set_client_name,
     command_set_device_led,
     command_switch,
@@ -64,6 +65,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     command_reboot.arg_parser(subparsers)
     command_reconnect_client.arg_parser(subparsers)
     command_certificate.arg_parser(subparsers)
+    command_set_ap_radio.arg_parser(subparsers)
     command_set_client_name.arg_parser(subparsers)
     command_set_device_led.arg_parser(subparsers)
     command_switch.arg_parser(subparsers)

--- a/src/tplink_omada_client/cli/command_set_ap_radio.py
+++ b/src/tplink_omada_client/cli/command_set_ap_radio.py
@@ -1,0 +1,101 @@
+"""Implementation for 'set-ap-radio' command"""
+
+from argparse import _SubParsersAction
+
+from tplink_omada_client.definitions import ChannelWidth, RadioId
+from tplink_omada_client.omadasiteclient import AccessPointRadioSettings
+
+from .config import get_target_config, to_omada_connection
+from .util import get_device_by_mac_or_name, get_target_argument
+
+_BANDS = {
+    "2g": RadioId.FREQ_2_4,
+    "5g": RadioId.FREQ_5_1,
+    "5g2": RadioId.FREQ_5_2,
+    "6g": RadioId.FREQ_6,
+}
+
+_WIDTHS = {
+    "20": ChannelWidth.WIDTH_20,
+    "40": ChannelWidth.WIDTH_40,
+    "80": ChannelWidth.WIDTH_80,
+    "160": ChannelWidth.WIDTH_160,
+    "240": ChannelWidth.WIDTH_240,
+    "320": ChannelWidth.WIDTH_320,
+}
+
+# "Auto" is a different value on each band
+_AUTO_WIDTHS = {
+    RadioId.FREQ_2_4: ChannelWidth.AUTO_40_20,
+    RadioId.FREQ_5_1: ChannelWidth.AUTO_80_40_20,
+    RadioId.FREQ_5_2: ChannelWidth.AUTO_80_40_20,
+    RadioId.FREQ_6: ChannelWidth.AUTO_160_80_40_20,
+}
+
+
+async def command_set_ap_radio(args) -> int:
+    """Executes 'set-ap-radio' command"""
+    controller = get_target_argument(args)
+    config = get_target_config(controller)
+
+    band = _BANDS[args["band"]]
+
+    width = None
+    if args["width"] is not None:
+        width = _AUTO_WIDTHS[band] if args["width"] == "auto" else _WIDTHS[args["width"]]
+
+    channel = None
+    if args["channel"] is not None:
+        channel = 0 if args["channel"] == "auto" else int(args["channel"])
+
+    radio_enabled = None
+    if args["enable"]:
+        radio_enabled = True
+    elif args["disable"]:
+        radio_enabled = False
+
+    settings = AccessPointRadioSettings(
+        radio_enabled=radio_enabled,
+        channel_width=width,
+        channel=channel,
+        tx_power=args["tx_power"],
+    )
+
+    async with to_omada_connection(config) as client:
+        site_client = await client.get_site_client(config.site)
+        device = await get_device_by_mac_or_name(site_client, args["mac"])
+        updated = await site_client.set_access_point_radio_settings(device, band, settings)
+
+        print(f"{device.name} {args['band']} radio:")
+        print(f"  Enabled:       {updated.radio_enabled}")
+        print(f"  Channel width: {updated.channel_width.name}")
+        print(f"  Channel:       {'auto' if updated.auto_channel else f'{updated.frequency} MHz'}")
+        print(f"  Tx power:      {updated.tx_power} dBm")
+        print("The access point may take a minute to apply the change.")
+    return 0
+
+
+def arg_parser(subparsers: _SubParsersAction) -> None:
+    """Configures arguments parser for 'set-ap-radio' command"""
+    parser = subparsers.add_parser("set-ap-radio", help="Sets the radio settings of an access point")
+    parser.add_argument(
+        "mac",
+        help="The MAC address or name of the access point",
+    )
+    parser.add_argument("band", choices=sorted(_BANDS), help="The radio band to configure")
+    parser.add_argument(
+        "-w",
+        "--width",
+        choices=[*sorted(_WIDTHS, key=int), "auto"],
+        help="Channel width in MHz",
+    )
+    parser.add_argument(
+        "-c",
+        "--channel",
+        help="The channel number to use, or 'auto' to let the access point choose",
+    )
+    parser.add_argument("-p", "--tx-power", type=int, help="Transmit power in dBm")
+    parser.add_argument("--enable", action="store_true", help="Switch the radio on")
+    parser.add_argument("--disable", action="store_true", help="Switch the radio off")
+
+    parser.set_defaults(func=command_set_ap_radio)

--- a/src/tplink_omada_client/definitions.py
+++ b/src/tplink_omada_client/definitions.py
@@ -301,6 +301,31 @@ class RadioId(IntEnum):
     def _missing_(cls, _):
         return RadioId.UNKNOWN
 
+    @property
+    def settings_key(self) -> str:
+        """Name of the field the controller uses for this radio's settings."""
+        return _RADIO_SETTINGS_KEYS[self]
+
+    @property
+    def status_key(self) -> str:
+        """Name of the field the controller uses for this radio's live status."""
+        return _RADIO_STATUS_KEYS[self]
+
+
+_RADIO_SETTINGS_KEYS = {
+    RadioId.FREQ_2_4: "radioSetting2g",
+    RadioId.FREQ_5_1: "radioSetting5g",
+    RadioId.FREQ_5_2: "radioSetting5g2",
+    RadioId.FREQ_6: "radioSetting6g",
+}
+
+_RADIO_STATUS_KEYS = {
+    RadioId.FREQ_2_4: "wp2g",
+    RadioId.FREQ_5_1: "wp5g",
+    RadioId.FREQ_5_2: "wp5g2",
+    RadioId.FREQ_6: "wp6g",
+}
+
 
 class WifiMode(IntEnum):
     """WiFi modes."""
@@ -331,6 +356,34 @@ class LedSetting(IntEnum):
     @classmethod
     def _missing_(cls, _):
         return LedSetting.UNKNOWN
+
+
+class ChannelWidth(IntEnum):
+    """Channel width of an access point radio.
+
+    The values form a single ladder shared by all bands. The AUTO_* members let
+    the access point pick any width up to the widest one named, and the
+    controller offers only one of them per band: AUTO_40_20 on 2.4GHz,
+    AUTO_80_40_20 on 5GHz, and AUTO_160_80_40_20 on 6GHz.
+
+    Which fixed widths a radio accepts depends on the hardware and on the
+    regulatory region, so the controller is the authority on what is legal.
+    """
+
+    UNKNOWN = -1
+    WIDTH_20 = 2
+    WIDTH_40 = 3
+    AUTO_40_20 = 4
+    WIDTH_80 = 5
+    AUTO_80_40_20 = 6
+    WIDTH_160 = 7
+    AUTO_160_80_40_20 = 8
+    WIDTH_240 = 9
+    WIDTH_320 = 10
+
+    @classmethod
+    def _missing_(cls, _):
+        return ChannelWidth.UNKNOWN
 
 
 class OmadaHardwareUpdateInfo(OmadaApiData):

--- a/src/tplink_omada_client/devices.py
+++ b/src/tplink_omada_client/devices.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from .definitions import (
     BandwidthControl,
+    ChannelWidth,
     DeviceStatus,
     DeviceStatusCategory,
     Eth802Dot1X,
@@ -22,6 +23,7 @@ from .definitions import (
     OmadaApiData,
     PoEMode,
     PortType,
+    RadioId,
 )
 
 
@@ -389,6 +391,150 @@ class OmadaAccesPointLanPortSettings(OmadaApiData):
         return self._data.get("poeOutEnable", False)
 
 
+class OmadaAccessPointRadioSettings(OmadaApiData):
+    """The configured settings of a single radio on an access point.
+
+    These are the values the controller has been asked to apply. The radio can
+    take a minute or two to adopt them, and a DFS channel is only used once the
+    radar check completes, so the live state can lag behind.
+    """
+
+    @property
+    def radio_enabled(self) -> bool:
+        """True if the radio is switched on."""
+        return self._data.get("radioEnable", False)
+
+    @property
+    def channel_width(self) -> ChannelWidth:
+        """The configured channel width."""
+        return ChannelWidth(int(self._data.get("channelWidth", -1)))
+
+    @property
+    def channel_index(self) -> int:
+        """The configured channel, as a 1-based index into the radio's channel list.
+
+        This is not the channel number. 0 means the access point picks the
+        channel automatically. Use OmadaApChannel to map between the two.
+        """
+        return int(self._data.get("channel", 0))
+
+    @property
+    def auto_channel(self) -> bool:
+        """True if the access point chooses the channel itself."""
+        return self.channel_index == 0
+
+    @property
+    def frequency(self) -> int:
+        """Centre frequency of the configured channel, in MHz. 0 when automatic."""
+        return self._data.get("freq", 0)
+
+    @property
+    def wireless_mode(self) -> int:
+        """The 802.11 mode of the radio. -2 means automatic."""
+        return self._data.get("wirelessMode", -2)
+
+    @property
+    def tx_power(self) -> int:
+        """Transmit power in dBm."""
+        return self._data.get("txPower", 0)
+
+    @property
+    def tx_power_level(self) -> int:
+        """Transmit power preset (0=Low, 1=Medium, 2=High, 3=Custom, 4=Auto)."""
+        return self._data.get("txPowerLevel", 0)
+
+
+class OmadaAccessPointRadioStatus(OmadaApiData):
+    """The live state of a single radio on an access point.
+
+    This is what the radio is actually doing, which can differ from the
+    configured settings while a change is being applied.
+    """
+
+    @property
+    def actual_channel(self) -> str:
+        """The channel currently in use, e.g. '36  / 5180MHz'."""
+        return self._data.get("actualChannel", "")
+
+    @property
+    def band_width(self) -> str:
+        """The channel width currently in use, e.g. '40MHz'."""
+        return self._data.get("bandWidth", "")
+
+    @property
+    def tx_power(self) -> int:
+        """Transmit power currently in use, in dBm."""
+        return self._data.get("txPower", 0)
+
+    @property
+    def max_tx_rate(self) -> int:
+        """Maximum PHY rate available at the current channel width, in Mbps."""
+        return self._data.get("maxTxRate", 0)
+
+    @property
+    def rx_utilization(self) -> int:
+        """Percentage of airtime spent receiving."""
+        return self._data.get("rxUtil", 0)
+
+    @property
+    def tx_utilization(self) -> int:
+        """Percentage of airtime spent transmitting."""
+        return self._data.get("txUtil", 0)
+
+    @property
+    def interference_utilization(self) -> int:
+        """Percentage of airtime lost to interference."""
+        return self._data.get("interUtil", 0)
+
+    @property
+    def wireless_mode(self) -> str:
+        """The 802.11 mode in use, e.g. 'a/n/ac mixed'."""
+        return self._data.get("rdMode", "")
+
+
+class OmadaApChannel(OmadaApiData):
+    """A channel that an access point radio can be set to.
+
+    The controller identifies channels by a 1-based index rather than by their
+    channel number, and the list depends on the regulatory region, so it has to
+    be read from the device rather than assumed.
+    """
+
+    @property
+    def index(self) -> int:
+        """The 1-based index the controller uses to select this channel."""
+        return self._data["value"]
+
+    @property
+    def channel(self) -> int:
+        """The 802.11 channel number."""
+        return self._data["channelValue"]
+
+    @property
+    def frequency(self) -> int:
+        """Centre frequency of the channel, in MHz."""
+        return self._data["freq"]
+
+    @property
+    def name(self) -> str:
+        """Display name of the channel, e.g. '36/5180MHz'."""
+        return self._data.get("channelName", "")
+
+
+class OmadaApRadioChannels(OmadaApiData):
+    """The channels available to one radio of an access point."""
+
+    @property
+    def band(self) -> str:
+        """The band these channels belong to, e.g. '5G'."""
+        return self._data.get("band", "")
+
+    @property
+    def channels(self) -> list[OmadaApChannel]:
+        """The channels the radio can be set to."""
+        return [OmadaApChannel(c) for c in self._data.get("channelList", [])]
+
+
 class OmadaAccessPoint(OmadaDetailedDevice):
     """Details of an Access Point connected to the controller."""
 
@@ -444,6 +590,25 @@ class OmadaAccessPoint(OmadaDetailedDevice):
         if uplink is None:
             return None
         return OmadaUplink(uplink)
+
+    def radio_settings(self, band: RadioId) -> OmadaAccessPointRadioSettings | None:
+        """The configured settings of one radio, or None if the AP has no such radio."""
+        data = self._data.get(band.settings_key)
+        if data is None:
+            return None
+        return OmadaAccessPointRadioSettings(data)
+
+    def radio_status(self, band: RadioId) -> OmadaAccessPointRadioStatus | None:
+        """The live state of one radio, or None if the AP has no such radio."""
+        data = self._data.get(band.status_key)
+        if data is None:
+            return None
+        return OmadaAccessPointRadioStatus(data)
+
+    @property
+    def radio_bands(self) -> list[RadioId]:
+        """The radios this access point actually has."""
+        return [band for band in RadioId if band != RadioId.UNKNOWN and band.settings_key in self._data]
 
 
 class OmadaSwitchPortDetails(OmadaSwitchPort):

--- a/src/tplink_omada_client/omadasiteclient.py
+++ b/src/tplink_omada_client/omadasiteclient.py
@@ -16,16 +16,21 @@ from .clients import (
 )
 from .definitions import (
     BandwidthControl,
+    ChannelWidth,
     Eth802Dot1X,
     LedSetting,
     LinkDuplex,
     LinkSpeed,
     NetworkTagsSetting,
     PoEMode,
+    RadioId,
 )
 from .devices import (
     OmadaAccesPointLanPortSettings,
     OmadaAccessPoint,
+    OmadaAccessPointRadioSettings,
+    OmadaApChannel,
+    OmadaApRadioChannels,
     OmadaDevice,
     OmadaFirmwareUpdate,
     OmadaGateway,
@@ -106,6 +111,21 @@ class AccessPointPortSettings:
     enable_poe: bool | None = None
     vlan_enable: bool | None = None
     vlan_id: int | None = None
+
+
+@dataclass
+class AccessPointRadioSettings:
+    """
+    Settings that can be applied to one radio of an access point
+
+    Specify the values you want to modify. The remaining values will be unaffected
+    """
+
+    radio_enabled: bool | None = None
+    channel_width: ChannelWidth | None = None
+    # The 802.11 channel number, e.g. 36. Use 0 to let the access point choose.
+    channel: int | None = None
+    tx_power: int | None = None
 
 
 @dataclass
@@ -428,6 +448,83 @@ class OmadaSiteClient:
         updated_ap = OmadaAccessPoint(result)
         # The caller probably only cares about the updated port status
         return next(p for p in updated_ap.lan_port_settings if p.port_name == port_name)
+
+    async def get_access_point_channels(self, mac_or_device: str | OmadaDevice) -> list[OmadaApRadioChannels]:
+        """Get the channels available to each radio of an access point.
+
+        The available channels depend on the hardware and on the regulatory
+        region, so they have to be read from the device.
+        """
+        mac = mac_or_device.mac if isinstance(mac_or_device, OmadaDevice) else mac_or_device
+        result = await self._api.request("get", self._api.format_url(f"eaps/{mac}/channelInfo", self._site_id))
+        return [OmadaApRadioChannels(r) for r in result.get("data", [])]
+
+    async def set_access_point_radio_settings(
+        self,
+        mac_or_device: str | OmadaDevice,
+        band: RadioId,
+        settings: AccessPointRadioSettings,
+    ) -> OmadaAccessPointRadioSettings:
+        """Update the settings of one radio on an access point.
+
+        Note that the access point takes a little while to apply the change, and
+        a DFS channel only comes into use once its radar check has completed, so
+        the radio status will not reflect the new settings immediately.
+        """
+        access_point = await self.get_access_point(mac_or_device)
+        existing = access_point.radio_settings(band)
+        if existing is None:
+            raise InvalidDevice(f"Access point {access_point.mac} has no {band.name} radio")
+
+        # The controller replaces the whole radio settings object, so start from
+        # the current values and apply only what the caller asked to change.
+        radio_payload = dict(existing.raw_data)
+
+        if settings.radio_enabled is not None:
+            radio_payload["radioEnable"] = settings.radio_enabled
+        if settings.channel_width is not None:
+            # The controller expects the channel width as a string
+            radio_payload["channelWidth"] = str(settings.channel_width.value)
+        if settings.tx_power is not None:
+            radio_payload["txPower"] = settings.tx_power
+        if settings.channel is not None:
+            if settings.channel == 0:
+                # Automatic channel selection. The frequency has to be cleared too.
+                radio_payload["channel"] = 0
+                radio_payload["freq"] = 0
+            else:
+                channel = await self._find_access_point_channel(access_point, band, settings.channel)
+                radio_payload["channel"] = channel.index
+                radio_payload["freq"] = channel.frequency
+
+        payload = {"channelLimitType": 0, band.settings_key: radio_payload}
+
+        await self._api.request(
+            "put",
+            self._api.format_url(f"eaps/{access_point.mac}/config/radios", self._site_id),
+            json=payload,
+        )
+
+        # The update response doesn't include the new settings, so read them back
+        updated_ap = await self.get_access_point(access_point.mac)
+        updated = updated_ap.radio_settings(band)
+        if updated is None:
+            raise InvalidDevice(f"Access point {access_point.mac} no longer reports a {band.name} radio")
+        return updated
+
+    async def _find_access_point_channel(self, access_point: OmadaAccessPoint, band: RadioId, channel: int) -> OmadaApChannel:
+        """Map an 802.11 channel number to the channel the controller expects."""
+        radios = await self.get_access_point_channels(access_point)
+        if band.value >= len(radios):
+            raise InvalidDevice(f"Access point {access_point.mac} has no channel list for its {band.name} radio")
+
+        available = radios[band.value].channels
+        for candidate in available:
+            if candidate.channel == channel:
+                return candidate
+
+        supported = ", ".join(str(c.channel) for c in available)
+        raise InvalidDevice(f"Channel {channel} is not available on the {band.name} radio of {access_point.mac}. Available: {supported}")
 
     def _build_base_port_payload(
         self,

--- a/tests/test_ap_radio_settings.py
+++ b/tests/test_ap_radio_settings.py
@@ -1,0 +1,236 @@
+"""Tests for access point radio settings."""
+
+import asyncio
+
+import pytest
+
+from tplink_omada_client.definitions import ChannelWidth, RadioId
+from tplink_omada_client.devices import OmadaAccessPoint
+from tplink_omada_client.exceptions import InvalidDevice
+from tplink_omada_client.omadasiteclient import AccessPointRadioSettings, OmadaSiteClient
+
+_5G_CHANNELS = [36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140]
+
+
+def _ap_data() -> dict:
+    return {
+        "mac": "AA-BB-CC-DD-EE-FF",
+        "name": "Test AP",
+        "type": "ap",
+        "radioSetting2g": {
+            "radioEnable": True,
+            "wirelessMode": -2,
+            "channelWidth": "4",
+            "channel": 0,
+            "freq": 0,
+            "txPower": 20,
+            "txPowerLevel": 4,
+        },
+        "radioSetting5g": {
+            "radioEnable": True,
+            "wirelessMode": -2,
+            "channelWidth": "2",
+            "channel": 1,
+            "freq": 5180,
+            "txPower": 23,
+            "txPowerLevel": 2,
+        },
+        "wp5g": {
+            "actualChannel": "36  / 5180MHz",
+            "bandWidth": "20MHz",
+            "txPower": 23,
+            "maxTxRate": 288,
+            "rxUtil": 2,
+            "txUtil": 1,
+            "interUtil": 0,
+            "rdMode": "a/n/ac mixed",
+        },
+    }
+
+
+def _channel_info() -> dict:
+    return {
+        "data": [
+            {
+                "band": "2.4G",
+                "channelList": [
+                    {"value": c, "channelValue": c, "freq": 2407 + 5 * c, "channelName": f"{c}/{2407 + 5 * c}MHz"} for c in range(1, 14)
+                ],
+            },
+            {
+                "band": "5G",
+                "channelList": [
+                    {"value": i, "channelValue": c, "freq": 5000 + 5 * c, "channelName": f"{c}/{5000 + 5 * c}MHz"}
+                    for i, c in enumerate(_5G_CHANNELS, start=1)
+                ],
+            },
+        ]
+    }
+
+
+class FakeApi:
+    """Stands in for the authenticated API connection."""
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, str, dict | None]] = []
+        self.ap = _ap_data()
+
+    def format_url(self, end_point: str, site: str | None = None) -> str:
+        return f"api/{site}/{end_point}"
+
+    async def request(self, method: str, url: str, params=None, json=None, data=None):
+        self.requests.append((method, url, json))
+        if method == "get" and url.endswith("/channelInfo"):
+            return _channel_info()
+        if method == "get" and "/eaps/" in url:
+            return self.ap
+        if method == "put" and url.endswith("/config/radios"):
+            # Reflect the change so the read-back sees it, like the controller does
+            for key, value in json.items():
+                if key.startswith("radioSetting"):
+                    self.ap[key] = value
+            return {}
+        raise AssertionError(f"Unexpected request: {method} {url}")
+
+    @property
+    def put_payload(self) -> dict:
+        """The body of the last radio config PUT."""
+        return next(body for method, url, body in reversed(self.requests) if method == "put" and body is not None)
+
+
+def _set(api: FakeApi, band: RadioId, settings: AccessPointRadioSettings):
+    client = OmadaSiteClient("site-1", api)
+    return asyncio.run(client.set_access_point_radio_settings("AA-BB-CC-DD-EE-FF", band, settings))
+
+
+def test_radio_settings_are_read_from_the_access_point():
+    ap = OmadaAccessPoint(_ap_data())
+
+    radio = ap.radio_settings(RadioId.FREQ_5_1)
+
+    assert radio is not None
+    assert radio.channel_width == ChannelWidth.WIDTH_20
+    assert radio.channel_index == 1
+    assert radio.frequency == 5180
+    assert not radio.auto_channel
+
+
+def test_auto_channel_is_reported_for_channel_zero():
+    ap = OmadaAccessPoint(_ap_data())
+
+    radio = ap.radio_settings(RadioId.FREQ_2_4)
+
+    assert radio is not None
+    assert radio.auto_channel
+    assert radio.channel_width == ChannelWidth.AUTO_40_20
+
+
+def test_missing_radio_returns_none():
+    ap = OmadaAccessPoint(_ap_data())
+
+    assert ap.radio_settings(RadioId.FREQ_6) is None
+    assert ap.radio_bands == [RadioId.FREQ_2_4, RadioId.FREQ_5_1]
+
+
+def test_unknown_channel_width_does_not_raise():
+    ap = OmadaAccessPoint({"radioSetting5g": {"channelWidth": "99"}})
+
+    radio = ap.radio_settings(RadioId.FREQ_5_1)
+
+    assert radio is not None
+    assert radio.channel_width == ChannelWidth.UNKNOWN
+
+
+def test_radio_status_reports_live_state():
+    ap = OmadaAccessPoint(_ap_data())
+
+    status = ap.radio_status(RadioId.FREQ_5_1)
+
+    assert status is not None
+    assert status.band_width == "20MHz"
+    assert status.max_tx_rate == 288
+
+
+def test_setting_channel_width_puts_to_the_radios_endpoint():
+    api = FakeApi()
+
+    _set(api, RadioId.FREQ_5_1, AccessPointRadioSettings(channel_width=ChannelWidth.WIDTH_80))
+
+    method, url, _ = next(r for r in api.requests if r[0] == "put")
+    assert url == "api/site-1/eaps/AA-BB-CC-DD-EE-FF/config/radios"
+    assert method == "put"
+
+
+def test_channel_width_is_sent_as_a_string():
+    api = FakeApi()
+
+    _set(api, RadioId.FREQ_5_1, AccessPointRadioSettings(channel_width=ChannelWidth.WIDTH_80))
+
+    assert api.put_payload["radioSetting5g"]["channelWidth"] == "5"
+
+
+def test_unchanged_settings_are_preserved():
+    api = FakeApi()
+
+    _set(api, RadioId.FREQ_5_1, AccessPointRadioSettings(channel_width=ChannelWidth.WIDTH_40))
+
+    radio = api.put_payload["radioSetting5g"]
+    # The controller replaces the whole object, so everything we did not change
+    # has to be sent back untouched
+    assert radio["txPower"] == 23
+    assert radio["txPowerLevel"] == 2
+    assert radio["wirelessMode"] == -2
+    assert radio["radioEnable"] is True
+
+
+def test_channel_number_is_converted_to_index_and_frequency():
+    api = FakeApi()
+
+    _set(api, RadioId.FREQ_5_1, AccessPointRadioSettings(channel=108))
+
+    radio = api.put_payload["radioSetting5g"]
+    # 108 is the 11th entry of the 5GHz channel list
+    assert radio["channel"] == 11
+    assert radio["freq"] == 5540
+
+
+def test_channel_zero_selects_automatic_and_clears_frequency():
+    api = FakeApi()
+
+    _set(api, RadioId.FREQ_5_1, AccessPointRadioSettings(channel=0))
+
+    radio = api.put_payload["radioSetting5g"]
+    assert radio["channel"] == 0
+    assert radio["freq"] == 0
+
+
+def test_channel_number_equals_index_on_2ghz():
+    api = FakeApi()
+
+    _set(api, RadioId.FREQ_2_4, AccessPointRadioSettings(channel=11))
+
+    radio = api.put_payload["radioSetting2g"]
+    assert radio["channel"] == 11
+    assert radio["freq"] == 2462
+
+
+def test_unavailable_channel_is_rejected():
+    api = FakeApi()
+
+    with pytest.raises(InvalidDevice, match="not available"):
+        _set(api, RadioId.FREQ_5_1, AccessPointRadioSettings(channel=165))
+
+
+def test_setting_a_radio_the_access_point_lacks_is_rejected():
+    api = FakeApi()
+
+    with pytest.raises(InvalidDevice, match="no FREQ_6 radio"):
+        _set(api, RadioId.FREQ_6, AccessPointRadioSettings(channel_width=ChannelWidth.WIDTH_80))
+
+
+def test_updated_settings_are_returned():
+    api = FakeApi()
+
+    updated = _set(api, RadioId.FREQ_5_1, AccessPointRadioSettings(channel_width=ChannelWidth.WIDTH_80))
+
+    assert updated.channel_width == ChannelWidth.WIDTH_80


### PR DESCRIPTION
Adds read and write access to access point radio settings — channel width, channel, transmit power and radio enable — on each of the 2.4GHz, 5GHz, 5GHz-2 and 6GHz radios.

The use case is a Home Assistant control to pin 5GHz channels and widths. The house is near an airport, so the APs keep getting radar-kicked off DFS channels and then all pile onto the same non-DFS block. Fixing that today means clicking through every access point in the web UI.

New on `OmadaSiteClient`:

- `set_access_point_radio_settings(mac_or_device, radio_id, AccessPointRadioSettings)`
- `get_access_point_channels(mac_or_device)`
- `OmadaAccessPoint.radio_settings(radio_id)` / `.radio_status(radio_id)`
- `ChannelWidth` IntEnum, reusing the existing `RadioId` for the band

## Notes for review

- **Endpoint**, captured from the web UI's traffic: the `eaps/{mac}` PATCH used by the other AP settings silently discards radio fields, so this uses `PUT eaps/{mac}/config/radios`. That replaces the whole radio object, so the setter reads current settings and applies changes on top.
- **A channel is an index, not a channel number** — 1-based, per-radio and region-dependent — so the setter takes the real channel number and maps it via `channelInfo`.
- Accessors return `None` for a radio the AP lacks; an unknown `channelWidth` becomes `UNKNOWN`.
- Happy to change: `settings_key` on `RadioId`, and one radio per call (there is a batch endpoint I left alone).

## Testing

- `uv run pytest` (14 new tests), `uv run ruff check .`
- Verified live against Omada Software Controller 5.15.24.19, on an EAP265 HD and EAP225-Outdoor
